### PR TITLE
Allow the prevention of the master fall through feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The makara subconfig sets up the proxy with a few of its own options, then provi
 * sticky - if a node should be stuck to once it's used during a specific context
 * master_ttl - how long the master context is persisted. generally, this needs to be longer than any replication lag
 * connection_error_matchers - array of custom error matchers you want to be handled gracefully by Makara (as in, errors matching these regexes will result in blacklisting the connection as opposed to raising directly).
+* master_fall_through - if reads should fall back to the master database if no replicas are available (default: true)
 
 Connection definitions contain any extra node-specific configurations. If the node should behave as a master you must provide `role: master`. Any previous configurations can be overridden within a specific node's config. Nodes can also contain weights if you'd like to balance usage based on hardware specifications. Optionally, you can provide a name attribute which will be used in sql logging.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Makara
 
-[![Build Status](https://travis-ci.org/taskrabbit/makara.png?branch=master)](https://travis-ci.org/taskrabbit/makara)
-[![Code Climate](https://codeclimate.com/repos/526886a7f3ea00679b00cae6/badges/7905f7a000492a1078f7/gpa.png)](https://codeclimate.com/repos/526886a7f3ea00679b00cae6/feed)
-
-
 Makara is generic master/slave proxy. It handles the heavy lifting of managing, choosing, blacklisting, and cycling through connections. It comes with an ActiveRecord database adapter implementation.
 
 #### Warning:
@@ -13,7 +9,7 @@ There is a potential performance issue when used alonside certain versions of [n
 ## Installation
 
 ```ruby
-gem 'makara', github: 'taskrabbit/makara', tag: 'v0.3.x'
+gem 'makara', github: 'BookBub/makara', tag: 'v0.3.x'
 ```
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ production:
     blacklist_duration: 5
     master_ttl: 5
     sticky: true
+    master_fall_through: true
 
     # list your connections with the override values (they're merged into the top-level config)
     # be sure to provide the role if master, role is assumed to be a slave if not provided

--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -7,7 +7,6 @@ module Makara
   autoload :ConnectionWrapper,  'makara/connection_wrapper'
   autoload :Context,            'makara/context'
   autoload :ErrorHandler,       'makara/error_handler'
-  autoload :Middleware,         'makara/middleware'
   autoload :Pool,               'makara/pool'
   autoload :Proxy,              'makara/proxy'
 

--- a/lib/makara/config_parser.rb
+++ b/lib/makara/config_parser.rb
@@ -23,7 +23,8 @@ module Makara
     DEFAULTS = {
       :master_ttl => 5,
       :blacklist_duration => 30,
-      :sticky => true
+      :sticky => true,
+      :master_fall_through => true
     }
 
     attr_reader :makara_config

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -40,14 +40,15 @@ module Makara
     attr_reader :sticky
 
     def initialize(config)
-      @config         = config.symbolize_keys
-      @config_parser  = Makara::ConfigParser.new(@config)
-      @id             = @config_parser.id
-      @ttl            = @config_parser.makara_config[:master_ttl]
-      @sticky         = @config_parser.makara_config[:sticky]
-      @hijacked       = false
-      @error_handler  ||= ::Makara::ErrorHandler.new
-      @skip_sticking  = false
+      @config              = config.symbolize_keys
+      @config_parser       = Makara::ConfigParser.new(@config)
+      @id                  = @config_parser.id
+      @ttl                 = @config_parser.makara_config[:master_ttl]
+      @sticky              = @config_parser.makara_config[:sticky]
+      @master_fall_through = @config_parser.makara_config[:master_fall_through]
+      @hijacked            = false
+      @error_handler       ||= ::Makara::ErrorHandler.new
+      @skip_sticking       = false
       instantiate_connections
     end
 
@@ -152,7 +153,7 @@ module Makara
         @master_pool
 
       # all slaves are down (or empty)
-      elsif @slave_pool.completely_blacklisted?
+      elsif @master_fall_through && @slave_pool.completely_blacklisted?
         stick_to_master(method_name, args)
         @master_pool
 

--- a/lib/makara/railtie.rb
+++ b/lib/makara/railtie.rb
@@ -1,9 +1,6 @@
 module Makara
   class Railtie < ::Rails::Railtie
 
-    config.app_middleware.use 'Makara::Middleware'
-
-
     initializer "makara.initialize_logger" do |app|
       ActiveRecord::LogSubscriber.log_subscribers.each do |subscriber|
         subscriber.extend ::Makara::Logging::Subscriber

--- a/spec/config_parser_spec.rb
+++ b/spec/config_parser_spec.rb
@@ -34,11 +34,11 @@ describe Makara::ConfigParser do
   it 'should provide master and slave configs' do
     parser = described_class.new(config)
     expect(parser.master_configs).to eq([
-      {:name => 'themaster', :top_level => 'value', :blacklist_duration => 30, :master_ttl => 5, :sticky => true}
+      {:name => 'themaster', :top_level => 'value', :blacklist_duration => 30, :master_ttl => 5, :sticky => true, :master_fall_through=>true}
     ])
     expect(parser.slave_configs).to eq([
-      {:name => 'slave1', :top_level => 'value', :blacklist_duration => 30, :master_ttl => 5, :sticky => true},
-      {:name => 'slave2', :top_level => 'value', :blacklist_duration => 30, :master_ttl => 5, :sticky => true}
+      {:name => 'slave1', :top_level => 'value', :blacklist_duration => 30, :master_ttl => 5, :sticky => true, :master_fall_through=>true},
+      {:name => 'slave2', :top_level => 'value', :blacklist_duration => 30, :master_ttl => 5, :sticky => true, :master_fall_through=>true}
     ])
   end
 


### PR DESCRIPTION
For usages where a read replica has different load than the master database the fall through feature could cause the master database to crash, thus it is desirable to prevent the master fall through feature even when all replicas are not available.
