### PR TITLE
Handle leading spaces in the SQL

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -103,7 +103,7 @@ module ActiveRecord
       SQL_MASTER_MATCHERS           = [/^\s*select.+for update$/i, /select.+lock in share mode$/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/^\s*select\s/i].map(&:freeze).freeze
       SQL_ALL_MATCHERS              = [/^\s*set\s/i].map(&:freeze).freeze
-      SQL_SKIP_STICKINESS_MATCHERS  = [/^\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /^(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
+      SQL_SKIP_STICKINESS_MATCHERS  = [/^\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /^\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
 
 
       def sql_master_matchers

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -100,10 +100,10 @@ module ActiveRecord
       hijack_method :execute, :select_rows, :exec_query
       send_to_all :connect, :disconnect!, :reconnect!, :verify!, :clear_cache!, :reset!
 
-      SQL_MASTER_MATCHERS           = [/^select.+for update$/i, /select.+lock in share mode$/i].map(&:freeze).freeze
-      SQL_SLAVE_MATCHERS            = [/^select\s/i].map(&:freeze).freeze
-      SQL_ALL_MATCHERS              = [/^set\s/i].map(&:freeze).freeze
-      SQL_SKIP_STICKINESS_MATCHERS  = [/^show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /^(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
+      SQL_MASTER_MATCHERS           = [/^\s*select.+for update$/i, /select.+lock in share mode$/i].map(&:freeze).freeze
+      SQL_SLAVE_MATCHERS            = [/^\s*select\s/i].map(&:freeze).freeze
+      SQL_ALL_MATCHERS              = [/^\s*set\s/i].map(&:freeze).freeze
+      SQL_SKIP_STICKINESS_MATCHERS  = [/^\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /^(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
 
 
       def sql_master_matchers

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -21,7 +21,9 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     'set @@things' => true,
     'commit' => true,
     'select * from felines' => false,
+    '    select * from felines' => false,
     'select * from users for update' => true,
+    '    select * from users for update' => true,
     'select * from users lock in share mode' => true,
     'select * from users where name = "for update"' => false,
     'select * from users where name = "lock in share mode"' => false

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -56,7 +56,7 @@ describe Makara::Middleware do
 
     status, headers, body = middleware.call(env)
 
-    expect(headers['Set-Cookie']).to eq("#{key}=#{Makara::Context.get_current}--200; path=/; max-age=5")
+    expect(headers['Set-Cookie']).to eq("#{key}=#{Makara::Context.get_current}--200; path=/; max-age=5; HttpOnly")
   end
 
   it 'should preserve the same context if the previous request was a redirect' do


### PR DESCRIPTION
In our project (postgres) the `needs_master?` method and friends were being passing SQL with leading spaces, which didn't match the regex and so _all_ queries ended up being routed to master.
