### PR TITLE
Use same logging rules as ActiveRecord

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -102,7 +102,7 @@ module ActiveRecord
 
       SQL_MASTER_MATCHERS           = [/^\s*select.+for update$/i, /select.+lock in share mode$/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/^\s*select\s/i].map(&:freeze).freeze
-      SQL_ALL_MATCHERS              = [/\A^\s*set\s/i].map(&:freeze).freeze
+      SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
       SQL_SKIP_STICKINESS_MATCHERS  = [/^\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /^\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
 
 

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -102,7 +102,7 @@ module ActiveRecord
 
       SQL_MASTER_MATCHERS           = [/^\s*select.+for update$/i, /select.+lock in share mode$/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/^\s*select\s/i].map(&:freeze).freeze
-      SQL_ALL_MATCHERS              = [/^\s*set\s/i].map(&:freeze).freeze
+      SQL_ALL_MATCHERS              = [/\A^\s*set\s/i].map(&:freeze).freeze
       SQL_SKIP_STICKINESS_MATCHERS  = [/^\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /^\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
 
 

--- a/lib/makara/logging/subscriber.rb
+++ b/lib/makara/logging/subscriber.rb
@@ -2,12 +2,17 @@ module Makara
   module Logging
 
     module Subscriber
+      IGNORE_PAYLOAD_NAMES = ["SCHEMA", "EXPLAIN"]
 
       def sql(event)
         name = event.payload[:name]
-        name = [current_wrapper_name(event), name].compact.join(' ')
-        event.payload[:name] = name
-        super(event)
+        if IGNORE_PAYLOAD_NAMES.include?(name)
+          self.class.runtime += event.duration
+        else
+          name = [current_wrapper_name(event), name].compact.join(' ')
+          event.payload[:name] = name
+          super(event)
+        end
       end
 
       protected

--- a/lib/makara/logging/subscriber.rb
+++ b/lib/makara/logging/subscriber.rb
@@ -7,7 +7,7 @@ module Makara
       def sql(event)
         name = event.payload[:name]
         if IGNORE_PAYLOAD_NAMES.include?(name)
-          self.class.runtime += event.duration
+          super
         else
           name = [current_wrapper_name(event), name].compact.join(' ')
           event.payload[:name] = name

--- a/lib/makara/logging/subscriber.rb
+++ b/lib/makara/logging/subscriber.rb
@@ -6,13 +6,11 @@ module Makara
 
       def sql(event)
         name = event.payload[:name]
-        if IGNORE_PAYLOAD_NAMES.include?(name)
-          super
-        else
+        unless IGNORE_PAYLOAD_NAMES.include?(name)
           name = [current_wrapper_name(event), name].compact.join(' ')
           event.payload[:name] = name
-          super(event)
         end
+        super(event)
       end
 
       protected

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -19,6 +19,7 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     'describe table' => true,
     'show index' => true,
     'set @@things' => true,
+    'SET @@things' => true,
     'commit' => true,
     'select * from felines' => false,
     '    select * from felines' => false,


### PR DESCRIPTION
Hey, thanks for this awesome gem :+1:

This commit reduces logging noise by using [the same rules as ActiveRecord uses](https://github.com/rails/rails/blob/b06f64c3480cd389d14618540d62da4978918af0/activerecord/lib/active_record/log_subscriber.rb#L33).
