### PR TITLE
Makara::Proxy.new calls super to use SimpleDelegate

### DIFF
--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -49,6 +49,7 @@ module Makara
       @error_handler  ||= ::Makara::ErrorHandler.new
       @skip_sticking  = false
       instantiate_connections
+      super(config)
     end
 
     def without_sticking


### PR DESCRIPTION
When ::ActiveRecord::Base.clear_active_connections! is executed in Rails 3,
it calls == on the connection. If initialize does not call super, the ==
method is not actually sent to the delegate, an ArgumentError: not delegated
error is raised.

Note that this does not happen in all instances, but is easily reproducible
when running Makara in the context of Sidekiq.
