### PR TITLE
current and previous contexts are stored in a thread local variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ ctx = Makara::Context.generate # or any unique sha
 Makara::Context.set_current ctx
 ```
 
+A context is local to the curent thread of execution. This will allow you to stick to master safely in a single thread
+in systems such as sidekiq, for instance.
+
 
 ### Forcing Master
 

--- a/lib/makara/context.rb
+++ b/lib/makara/context.rb
@@ -38,7 +38,7 @@ module Makara
 
       def set_current_thread_local(type,context)
         t = Thread.current
-        t.respond_to?(:thread_variable_set) ? t.thread_variable_set(type,context) : t[type]=contex
+        t.respond_to?(:thread_variable_set) ? t.thread_variable_set(type,context) : t[type]=context
       end
 
     end

--- a/lib/makara/context.rb
+++ b/lib/makara/context.rb
@@ -31,12 +31,14 @@ module Makara
       protected
 
       def get_current_thread_local_for(type)
-        current = Thread.current.thread_variable_get(type)
+        t = Thread.current
+        current = t.respond_to?(:thread_variable_get) ? t.thread_variable_get(type) : t[type]
         current ||= set_current_thread_local(type,generate)
       end
 
       def set_current_thread_local(type,context)
-        Thread.current.thread_variable_set(type,context)
+        t = Thread.current
+        t.respond_to?(:thread_variable_set) ? t.thread_variable_set(type,context) : t[type]=contex
       end
 
     end

--- a/lib/makara/context.rb
+++ b/lib/makara/context.rb
@@ -7,30 +7,36 @@ module Makara
   class Context
     class << self
 
-
       def generate(seed = nil)
         seed ||= "#{Time.now.to_i}#{Thread.current.object_id}#{rand(99999)}"
         Digest::MD5.hexdigest(seed)
       end
 
-
       def get_previous
-        @previous_context ||= generate
+        get_current_thread_local_for(:makara_context_previous)
       end
-
 
       def set_previous(context)
-        @previous_context = context
+        set_current_thread_local(:makara_context_previous,context)
       end
-
 
       def get_current
-        @current_context ||= generate
+        get_current_thread_local_for(:makara_context_current)
       end
 
-
       def set_current(context)
-        @current_context = context
+        set_current_thread_local(:makara_context_current,context)
+      end
+
+      protected
+
+      def get_current_thread_local_for(type)
+        current = Thread.current.thread_variable_get(type)
+        current ||= set_current_thread_local(type,generate)
+      end
+
+      def set_current_thread_local(type,context)
+        Thread.current.thread_variable_set(type,context)
       end
 
     end

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe Makara::Context do
+
+  describe 'get_current' do
+    it 'does not share context acorss threads' do
+      uniq_curret_contexts = []
+      threads = []
+
+      1.upto(3).map do |i|
+        threads << Thread.new do
+          current = Makara::Context.get_current
+          expect(current).to_not be_nil
+          expect(uniq_curret_contexts).to_not include(current)
+          uniq_curret_contexts << current
+
+          sleep(0.2)
+        end
+        sleep(0.1)
+      end
+
+      threads.map(&:join)
+      expect(uniq_curret_contexts.uniq.count).to eq(3)
+    end
+  end
+
+  describe 'set_current' do
+
+    it 'does not share context acorss threads' do
+      uniq_curret_contexts = []
+      threads = []
+
+      1.upto(3).map do |i|
+        threads << Thread.new do
+
+          current = Makara::Context.set_current("val#{i}")
+          expect(current).to_not be_nil
+          expect(current).to eq("val#{i}")
+
+          sleep(0.2)
+
+          current = Makara::Context.get_current
+          expect(current).to_not be_nil
+          expect(current).to eq("val#{i}")
+
+          uniq_curret_contexts << current
+        end
+        sleep(0.1)
+      end
+
+      threads.map(&:join)
+      expect(uniq_curret_contexts.uniq.count).to eq(3)
+    end
+  end
+
+  describe 'get_previous' do
+    it 'does not share context acorss threads' do
+      uniq_curret_contexts = []
+      threads = []
+
+      1.upto(3).map do |i|
+        threads << Thread.new do
+          current = Makara::Context.get_previous
+          expect(current).to_not be_nil
+          expect(uniq_curret_contexts).to_not include(current)
+          uniq_curret_contexts << current
+
+          sleep(0.2)
+        end
+        sleep(0.1)
+      end
+
+      threads.map(&:join)
+      expect(uniq_curret_contexts.uniq.count).to eq(3)
+    end
+  end
+
+  describe 'set_previous' do
+    it 'does not share context acorss threads' do
+      uniq_curret_contexts = []
+      threads = []
+
+      1.upto(3).map do |i|
+        threads << Thread.new do
+
+          current = Makara::Context.set_previous("val#{i}")
+          expect(current).to_not be_nil
+          expect(current).to eq("val#{i}")
+
+          sleep(0.2)
+
+          current = Makara::Context.get_previous
+          expect(current).to_not be_nil
+          expect(current).to eq("val#{i}")
+
+          uniq_curret_contexts << current
+        end
+        sleep(0.1)
+      end
+
+      threads.map(&:join)
+      expect(uniq_curret_contexts.uniq.count).to eq(3)
+    end
+  end
+
+end
+


### PR DESCRIPTION
context is now thread safe. can be used in a system like sidekiq
