### PR TITLE
Improved Postgresql compatibility and failover support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
   - 2.0.0
   - 2.1.1
   - jruby
@@ -29,18 +26,3 @@ before_script:
 before_install:
   - gem update --system 2.1.11
   - gem --version
-
-matrix:
-  exclude:
-    - rvm: 1.8.7
-      gemfile: gemfiles/ar40.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/ar40.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/ar41.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/ar41.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/ar42.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/ar42.gemfile

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -24,7 +24,10 @@ module ActiveRecord
           /cannot connect/,
           /connection[^:]+closed/,
           /can\'t get socket descriptor/,
-          /connection to [a-z0-9.]+:[0-9]+ refused/
+          /connection to [a-z0-9.]+:[0-9]+ refused/,
+          /timeout expired/,
+          /could not translate host name/,
+          /the database system is (starting|shutting)/
         ].map(&:freeze).freeze
 
 

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -16,15 +16,15 @@ module ActiveRecord
 
 
         CONNECTION_MATCHERS = [
-          /(closed|lost|no|terminating|terminated)\s?([^\s]+)?\sconnection/i,
-          /gone away/i,
-          /connection[^:]+refused/i,
-          /could not connect/i,
-          /can\'t connect/i,
-          /cannot connect/i,
-          /connection[^:]+closed/i,
-          /can\'t get socket descriptor/i,
-          /connection to [a-zA-Z0-9.]+:[0-9]+ refused/i
+          /(closed|lost|no|terminating|terminated)\s?([^\s]+)?\sconnection/,
+          /gone away/,
+          /connection[^:]+refused/,
+          /could not connect/,
+          /can\'t connect/,
+          /cannot connect/,
+          /connection[^:]+closed/,
+          /can\'t get socket descriptor/,
+          /connection to [a-z0-9.]+:[0-9]+ refused/
         ].map(&:freeze).freeze
 
 

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -23,7 +23,8 @@ module ActiveRecord
           /can\'t connect/i,
           /cannot connect/i,
           /connection[^:]+closed/i,
-          /can\'t get socket descriptor/i
+          /can\'t get socket descriptor/i,
+          /connection to [a-zA-Z0-9.]+:[0-9]+ refused/i
         ].map(&:freeze).freeze
 
 
@@ -101,7 +102,7 @@ module ActiveRecord
 
 
       hijack_method :execute, :select_rows, :exec_query, :transaction
-      send_to_all :connect, :disconnect!, :reconnect!, :verify!, :clear_cache!, :reset!
+      send_to_all :connect, :reconnect!, :verify!, :clear_cache!, :reset!
 
       SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/\A\s*select\s/i].map(&:freeze).freeze

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -95,7 +95,11 @@ module Makara
 
     # we want to forward all private methods, since we could have kicked out from a private scenario
     def method_missing(m, *args, &block)
-       _makara_connection.__send__(m, *args, &block)
+      if _makara_connection.respond_to?(m)
+        _makara_connection.public_send(m, *args, &block)
+      else # probably private method
+        _makara_connection.__send__(m, *args, &block)
+      end
     end
 
 

--- a/lib/makara/errors/blacklist_connection.rb
+++ b/lib/makara/errors/blacklist_connection.rb
@@ -2,7 +2,10 @@ module Makara
   module Errors
     class BlacklistConnection < ::StandardError
 
+      attr_reader :original_error
+
       def initialize(connection, error)
+        @original_error = error
         super "[Makara/#{connection._makara_name}] #{error.message}"
       end
 

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -72,7 +72,13 @@ module Makara
 
     def method_missing(m, *args, &block)
       any_connection do |con|
-        con.respond_to?(m, true) ? con.__send__(m, *args, &block) : super(m, *args, &block)
+        if con.respond_to?(m)
+          con.public_send(m, *args, &block)
+        elsif con.respond_to?(m, true)
+          con.__send__(m, *args, &block)
+        else
+          super(m, *args, &block)
+        end
       end
     end
 

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -95,6 +95,12 @@ module Makara
       fake_wrapper
     end
 
+    def disconnect!
+      send_to_all(:disconnect!)
+    rescue ::Makara::Errors::AllConnectionsBlacklisted, ::Makara::Errors::NoConnectionsAvailable
+      # all connections are already down, nothing to do here
+    end
+
     protected
 
 
@@ -242,7 +248,6 @@ module Makara
       yield
     rescue ::Makara::Errors::NoConnectionsAvailable => e
       if e.role == 'master'
-        return if method_name == :disconnect!
         Kernel.raise ::Makara::Errors::NoConnectionsAvailable.new('master and slave')
       end
       @slave_pool.disabled = true

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
@@ -35,7 +35,8 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter::ErrorHandler d
     %|PG::AdminShutdown: FATAL:  terminating connection due to administrator command FATAL:  terminating connection due to administrator command|,
     %|PG::ConnectionBad: PQconsumeInput() SSL connection has been closed unexpectedly: SELECT  1 AS one FROM "users"  WHERE "users"."registration_ip" = '10.0.2.2' LIMIT 1|,
     %|PG::UnableToSend: no connection to the server|,
-    %|PG::ConnectionBad (could not connect to server: Connection refused|
+    %|PG::ConnectionBad (could not connect to server: Connection refused|,
+    %|PG::ConnectionBad: PQsocket() can't get socket descriptor:|
   ].each do |msg|
     it "should properly evaluate connection messages like: #{msg}" do
       expect(handler).to be_connection_message(msg)

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
@@ -36,7 +36,8 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter::ErrorHandler d
     %|PG::ConnectionBad: PQconsumeInput() SSL connection has been closed unexpectedly: SELECT  1 AS one FROM "users"  WHERE "users"."registration_ip" = '10.0.2.2' LIMIT 1|,
     %|PG::UnableToSend: no connection to the server|,
     %|PG::ConnectionBad (could not connect to server: Connection refused|,
-    %|PG::ConnectionBad: PQsocket() can't get socket descriptor:|
+    %|PG::ConnectionBad: PQsocket() can't get socket descriptor:|,
+    %|org.postgresql.util.PSQLException: Connection to localhost:123 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.|
   ].each do |msg|
     it "should properly evaluate connection messages like: #{msg}" do
       expect(handler).to be_connection_message(msg)

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
@@ -37,7 +37,11 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter::ErrorHandler d
     %|PG::UnableToSend: no connection to the server|,
     %|PG::ConnectionBad (could not connect to server: Connection refused|,
     %|PG::ConnectionBad: PQsocket() can't get socket descriptor:|,
-    %|org.postgresql.util.PSQLException: Connection to localhost:123 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.|
+    %|org.postgresql.util.PSQLException: Connection to localhost:123 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.|,
+    %|PG::ConnectionBad: timeout expired|,
+    %|PG::ConnectionBad: could not translate host name "some.sample.com" to address: Name or service not known|,
+    %|PG::ConnectionBad: FATAL: the database system is starting up|,
+    %|PG::ConnectionBad: FATAL: the database system is shutting down|
   ].each do |msg|
     it "should properly evaluate connection messages like: #{msg}" do
       expect(handler).to be_connection_message(msg)

--- a/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
@@ -10,13 +10,8 @@ describe 'MakaraMysql2Adapter' do
     base
   }
 
-  before do
-    if ActiveRecord::Base.connected?
-      ActiveRecord::Base.connection.tap do |c|
-        c.master_pool.connections.each(&:_makara_whitelist!)
-        c.slave_pool.connections.each(&:_makara_whitelist!)
-      end
-    end
+  before :each do
+    ActiveRecord::Base.clear_all_connections!
     change_context
   end
 

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -105,6 +105,10 @@ describe 'MakaraPostgreSQLAdapter' do
 
     context 'with only slave connection' do
       it 'should raise error only on write' do
+        ActiveRecord::Base.establish_connection(config)
+        load(File.dirname(__FILE__) + '/../../support/schema.rb')
+        ActiveRecord::Base.clear_all_connections!
+
         custom_config = config.deep_dup
         custom_config['makara']['connections'].select{|h| h['role'] == 'master' }.each{|h| h['port'] = '1'}
 

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -13,13 +13,8 @@ describe 'MakaraPostgreSQLAdapter' do
 
   let(:connection) { ActiveRecord::Base.connection }
 
-  before do
-    if ActiveRecord::Base.connected?
-      ActiveRecord::Base.connection.tap do |c|
-        c.master_pool.connections.each(&:_makara_whitelist!)
-        c.slave_pool.connections.each(&:_makara_whitelist!)
-      end
-    end
+  before :each do
+    ActiveRecord::Base.clear_all_connections!
     change_context
   end
 
@@ -87,7 +82,7 @@ describe 'MakaraPostgreSQLAdapter' do
 
   context 'without live connections' do
       it 'should raise errors on read or write' do
-        allow(ActiveRecord::Base).to receive(:postgresql_connection).and_raise(PG::ConnectionBad.new('could not connect to server: Connection refused'))
+        allow(ActiveRecord::Base).to receive(:postgresql_connection).and_raise(StandardError.new('could not connect to server: Connection refused'))
 
         ActiveRecord::Base.establish_connection(config)
         expect { connection.execute('SELECT * FROM users') }.to raise_error(Makara::Errors::NoConnectionsAvailable)

--- a/spec/connection_wrapper_spec.rb
+++ b/spec/connection_wrapper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Makara::ConnectionWrapper do
 
   let(:proxy){ FakeProxy.new({:makara => {:blacklist_duration => 5, :connections => [{:role => 'master'}, {:role => 'slave'}, {:role => 'slave'}]}}) }
-  let(:connection){ subject.__getobj__ }
+  let(:connection){ subject._makara_connection }
 
   subject{ proxy.master_pool.connections.first }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
   require "#{File.dirname(__FILE__)}/support/pool_extensions"
   require "#{File.dirname(__FILE__)}/support/configurator"
   require "#{File.dirname(__FILE__)}/support/mock_objects"
+  require "#{File.dirname(__FILE__)}/support/deep_dup"
 
   config.include Configurator
 

--- a/spec/support/deep_dup.rb
+++ b/spec/support/deep_dup.rb
@@ -1,0 +1,12 @@
+unless Hash.respond_to?(:deep_dup)
+  class Hash
+    def deep_dup
+      duplicate = self.dup
+      duplicate.each_pair do |k,v|
+        tv = duplicate[k]
+        duplicate[k] = tv.is_a?(Hash) && v.is_a?(Hash) ? tv.deep_dup : v
+      end
+      duplicate
+    end
+  end
+end

--- a/spec/support/mock_objects.rb
+++ b/spec/support/mock_objects.rb
@@ -2,6 +2,8 @@ require 'active_record/connection_adapters/makara_abstract_adapter'
 
 class FakeConnection < Struct.new(:config)
 
+  attr_accessor :something
+
   def ping
     'ping!'
   end
@@ -12,6 +14,14 @@ class FakeConnection < Struct.new(:config)
 
   def query(content)
     []
+  end
+
+  def active?
+    true
+  end
+
+  def disconnect!
+    true
   end
 end
 
@@ -27,6 +37,10 @@ class FakeDatabaseAdapter < Struct.new(:config)
 
   def select_rows(sql, name = nil)
     []
+  end
+
+  def active?
+    true
   end
 
 end


### PR DESCRIPTION
Fixes #27.

As far as I can see, it has been fixed in #35, but then these changes was removed in #52 because of #50 SystemStackError and other issues.

So this PR is doing almost same the same stuff as #35, but a bit more deeply and also includes few more bugfixes (including a fix for #50).

It allows the app to start and run with any set of working/down DB servers and raises errors only on write queries when master is down and on all queries when all servers are down.
