### PR TITLE
Instrument Cache, Context and Proxy with notification callbacks

### DIFF
--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -8,6 +8,7 @@ module Makara
   autoload :Context,            'makara/context'
   autoload :ErrorHandler,       'makara/error_handler'
   autoload :Middleware,         'makara/middleware'
+  autoload :Notifications,      'makara/notifications'
   autoload :Pool,               'makara/pool'
   autoload :Proxy,              'makara/proxy'
 

--- a/lib/makara/cache.rb
+++ b/lib/makara/cache.rb
@@ -16,10 +16,13 @@ module Makara
       end
 
       def read(key)
-        store.try(:read, key)
+        store.try(:read, key).tap do |value|
+          Notifications.notify!('Cache:read', key, value)
+        end
       end
 
       def write(key, value, ttl)
+        Notifications.notify!('Cache:write', key, value, ttl)
         store.try(:write, key, value, :expires_in => ttl.to_i)
       end
 

--- a/lib/makara/context.rb
+++ b/lib/makara/context.rb
@@ -13,18 +13,24 @@ module Makara
       end
 
       def get_previous
-        get_current_thread_local_for(:makara_context_previous)
+        get_current_thread_local_for(:makara_context_previous).tap do |context|
+          Notifications.notify!('Context:get_previous', context)
+        end
       end
 
       def set_previous(context)
+        Notifications.notify!('Context:set_previous', context)
         set_current_thread_local(:makara_context_previous,context)
       end
 
       def get_current
-        get_current_thread_local_for(:makara_context_current)
+        get_current_thread_local_for(:makara_context_current).tap do |context|
+          Notifications.notify!('Context:get_current', context)
+        end
       end
 
       def set_current(context)
+        Notifications.notify!('Context:set_current', context)
         set_current_thread_local(:makara_context_current,context)
       end
 

--- a/lib/makara/notifications.rb
+++ b/lib/makara/notifications.rb
@@ -1,0 +1,40 @@
+module Makara
+  # A notification handler that allows users to register arbitrary instrumentation callbacks. For instance, this can be
+  # used to fire dtrace or strace probes, or to write log messages. Callbacks are in the form of blocks, which can take
+  # 0 to N arguments, where N is the number of arguments provided to the the :notify!: method.
+  #
+  # Example:
+  #
+  #   Makara::Cache instruments the :write: method as follows:
+  #
+  #     Notifications.notify!('Cache:write', key, value, ttl)
+  #
+  #   Callbacks can be registered as follows:
+  #
+  #     Notifications.register_callback('Cache:write') do |key|
+  #       puts "Makara::Cache.write: #{key}"
+  #     end
+  #
+  #     Notifications.register_callback('Cache:write') do |key, value|
+  #       puts "Makara::Cache.write: #{key}: #{value}"
+  #     end
+  #
+  module Notifications
+    class << self
+      def register_callback(name, &blk)
+        registered_callbacks[name] << blk
+      end
+
+      def notify!(name, *args)
+        return unless registered_callbacks[name]
+        registered_callbacks[name].each do |callback|
+          callback.call(*args)
+        end
+      end
+
+      def registered_callbacks
+        @registered_callbacks ||= Hash.new([])
+      end
+    end
+  end
+end

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -169,15 +169,18 @@ module Makara
     def _appropriate_pool(method_name, args)
       # the args provided absolutely need master
       if needs_master?(method_name, args)
+        Notifications.notify!('Proxy:appropriate_pool:master')
         stick_to_master(method_name, args)
         @master_pool
 
       # in this context, we've already stuck to master
       elsif Makara::Context.get_current == @master_context
+        Notifications.notify!('Proxy:appropriate_pool:master')
         @master_pool
 
       # the previous context stuck us to master
       elsif previously_stuck_to_master?
+        Notifications.notify!('Proxy:appropriate_pool:master')
 
         # we're only on master because of the previous context so
         # behave like we're sticking to master but store the current context
@@ -186,11 +189,13 @@ module Makara
 
       # all slaves are down (or empty)
       elsif @slave_pool.completely_blacklisted?
+        Notifications.notify!('Proxy:appropriate_pool:master')
         stick_to_master(method_name, args)
         @master_pool
 
       # yay! use a slave
       else
+        Notifications.notify!('Proxy:appropriate_pool:replica')
         @slave_pool
       end
     end
@@ -216,6 +221,7 @@ module Makara
 
 
     def stick_to_master(method_name, args, write_to_cache = true)
+      Notifications.notify!('Proxy:stick_to_master', method_name, args, write_to_cache)
       # if we're already stuck to master, don't bother doing it again
       return if @master_context == Makara::Context.get_current
 

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -24,6 +24,18 @@ describe Makara::Cache do
     expect(described_class.read('test')).to be_nil
   end
 
+  context 'notifications' do
+    before { allow(Makara::Notifications).to receive(:notify!) }
+
+    it 'notifies on read and write' do
+      described_class.read('test')
+      expect(Makara::Notifications).to have_received(:notify!).with('Cache:read', 'test', nil)
+      described_class.write('test', 'value', 10)
+      expect(Makara::Notifications).to have_received(:notify!).with('Cache:write', 'test', 'value', 10)
+      described_class.read('test')
+      expect(Makara::Notifications).to have_received(:notify!).with('Cache:read', 'test', 'value')
+    end
+  end
 
   # this will be used in tests so we have to ensure this works as expected
   context Makara::Cache::MemoryStore do

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -1,18 +1,19 @@
 require 'spec_helper'
 
 describe Makara::Context do
+  before { allow(Makara::Notifications).to receive(:notify!) }
 
   describe 'get_current' do
-    it 'does not share context acorss threads' do
-      uniq_curret_contexts = []
+    it 'does not share context across threads' do
+      uniq_current_contexts = []
       threads = []
 
       1.upto(3).map do |i|
         threads << Thread.new do
           current = Makara::Context.get_current
           expect(current).to_not be_nil
-          expect(uniq_curret_contexts).to_not include(current)
-          uniq_curret_contexts << current
+          expect(uniq_current_contexts).to_not include(current)
+          uniq_current_contexts << current
 
           sleep(0.2)
         end
@@ -20,14 +21,19 @@ describe Makara::Context do
       end
 
       threads.map(&:join)
-      expect(uniq_curret_contexts.uniq.count).to eq(3)
+      expect(uniq_current_contexts.uniq.count).to eq(3)
+    end
+
+    it 'sends a notification' do
+      current_context = Makara::Context.get_current
+      expect(Makara::Notifications).to have_received(:notify!).with('Context:get_current', current_context)
     end
   end
 
   describe 'set_current' do
 
-    it 'does not share context acorss threads' do
-      uniq_curret_contexts = []
+    it 'does not share context across threads' do
+      uniq_current_contexts = []
       threads = []
 
       1.upto(3).map do |i|
@@ -43,27 +49,32 @@ describe Makara::Context do
           expect(current).to_not be_nil
           expect(current).to eq("val#{i}")
 
-          uniq_curret_contexts << current
+          uniq_current_contexts << current
         end
         sleep(0.1)
       end
 
       threads.map(&:join)
-      expect(uniq_curret_contexts.uniq.count).to eq(3)
+      expect(uniq_current_contexts.uniq.count).to eq(3)
+    end
+
+    it 'sends a notification' do
+      Makara::Context.set_current('current_context')
+      expect(Makara::Notifications).to have_received(:notify!).with('Context:set_current', 'current_context')
     end
   end
 
   describe 'get_previous' do
-    it 'does not share context acorss threads' do
-      uniq_curret_contexts = []
+    it 'does not share context across threads' do
+      uniq_current_contexts = []
       threads = []
 
       1.upto(3).map do |i|
         threads << Thread.new do
           current = Makara::Context.get_previous
           expect(current).to_not be_nil
-          expect(uniq_curret_contexts).to_not include(current)
-          uniq_curret_contexts << current
+          expect(uniq_current_contexts).to_not include(current)
+          uniq_current_contexts << current
 
           sleep(0.2)
         end
@@ -71,13 +82,19 @@ describe Makara::Context do
       end
 
       threads.map(&:join)
-      expect(uniq_curret_contexts.uniq.count).to eq(3)
+      expect(uniq_current_contexts.uniq.count).to eq(3)
+    end
+
+    it 'sends a notification' do
+      previous_context = Makara::Context.get_previous
+      expect(previous_context).not_to be nil
+      expect(Makara::Notifications).to have_received(:notify!).with('Context:get_previous', previous_context)
     end
   end
 
   describe 'set_previous' do
-    it 'does not share context acorss threads' do
-      uniq_curret_contexts = []
+    it 'does not share context across threads' do
+      uniq_current_contexts = []
       threads = []
 
       1.upto(3).map do |i|
@@ -93,13 +110,18 @@ describe Makara::Context do
           expect(current).to_not be_nil
           expect(current).to eq("val#{i}")
 
-          uniq_curret_contexts << current
+          uniq_current_contexts << current
         end
         sleep(0.1)
       end
 
       threads.map(&:join)
-      expect(uniq_curret_contexts.uniq.count).to eq(3)
+      expect(uniq_current_contexts.uniq.count).to eq(3)
+    end
+
+    it 'sends a notification' do
+      Makara::Context.set_previous('previous_context')
+      expect(Makara::Notifications).to have_received(:notify!).with('Context:set_previous', 'previous_context')
     end
   end
 

--- a/spec/notifications_spec.rb
+++ b/spec/notifications_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Makara::Notifications do
+  describe '#notify!' do
+    context 'without any registered callbacks' do
+      it 'does not raise' do
+        expect {
+          Makara::Notifications.notify!('Some:instrumentation:point', 'with', 4, 'arbitrary', 'arguments')
+        }.not_to raise_error
+      end
+    end
+
+    context 'with registered callbacks' do
+      it 'calls all notification callbacks' do
+        @first_notification = @second_notification = @third_notification = false
+
+        Makara::Notifications.register_callback('Notification:test') do
+          @first_notification = true
+        end
+
+        Makara::Notifications.register_callback('Notification:test') do |arg1|
+          @second_notification = arg1
+        end
+
+        Makara::Notifications.register_callback('Notification:test') do |arg1, arg2|
+          @third_notification = [arg1, arg2]
+        end
+
+        Makara::Notifications.notify!('Notification:test', 'one', 'two')
+
+        expect(@first_notification).to be true
+        expect(@second_notification).to eq('one')
+        expect(@third_notification).to eq(['one', 'two'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Code fires notifications using a Makara::Notifications module. Users may register arbitrary callbacks for these instrumentation points.
