### PR TITLE
Update missing CHANGELOG from v0.3.0 to v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,80 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## 0.3.0rc2 - 2014-08-05
+## v0.3.5 - 2016-01-08
+
+[Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.4.rc1...v0.3.5)
+
+### Changed
+
+- Raise `Makara::Errors::AllConnectionsBlacklisted` on timeout. [#104](https://github.com/taskrabbit/makara/pull/104) Brian Leonard
+
+## v0.3.4.rc1 - 2016-01-06
+
+[Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.3...v0.3.4.rc1)
+
+### Added
+
+- Add `url` to database connections configurations. [#93](https://github.com/taskrabbit/makara/pull/93) Benjamin Fleischer
+
+### Changed
+
+- Improve Postgresql compatibility and failover support, also fix [#78](https://github.com/taskrabbit/makara/issues/78), [#79](https://github.com/taskrabbit/makara/issues/79). [#87](https://github.com/taskrabbit/makara/pull/87) Vlad
+- Update README: Specify newrelic_rpm gem versions that will have the performance issue. [#95](https://github.com/taskrabbit/makara/pull/95) Benjamin Fleischer
+
+## v0.3.3 - 2015-05-20
+
+[Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.2...v0.3.3)
+
+### Changed
+
+- A context is local to the curent thread of execution. This will allow you to stick to master safely in a single thread
+ +in systems such as sidekiq, for instance. Fix [#83](https://github.com/taskrabbit/makara/issues/83). [#84](https://github.com/taskrabbit/makara/pull/84) Matt Camuto
+
+## v0.3.2 - 2015-05-16
+
+[Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.1...v0.3.2)
+
+### Fixed
+
+- Fix a `ArgumentError: not delegated` error for rails 3. [#82](https://github.com/taskrabbit/makara/pull/82) Eric Saxby
+
+### Changed
+
+- Switch log format from `:info` to `:error`. Mike Nelson
+
+## v0.3.1 - 2015-05-08
+
+[Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.0...v0.3.1)
+
+### Changed
+
+- Globally move to multiline matchers. Mike Nelson
+
+### Changed
+
+## v0.3.0 - 2015-04-27
+
+[Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.0.rc3...v0.3.0)
+
+### Changed
+
+- Reduce logging noise by using [the same rules as ActiveRecord uses](https://github.com/rails/rails/blob/b06f64c3480cd389d14618540d62da4978918af0/activerecord/lib/active_record/log_subscriber.rb#L33). [#76](https://github.com/taskrabbit/makara/pull/76) Andrew Kane
+
+### Fixed
+
+- Fix an issue for postgres that would route all queries to master. [#72](https://github.com/taskrabbit/makara/pull/72) Kali Donovan
+- Fix an edge case which would cause SET operations to send to all connections([#70](https://github.com/taskrabbit/makara/issues/70)). [#80](https://github.com/taskrabbit/makara/pull/80) Michael Amor Righi
+- Fix performance regression with certain verions of [newrelic/rpm](https://github.com/newrelic/rpm)([#59](https://github.com/taskrabbit/makara/issues/59)). [#75](https://github.com/taskrabbit/makara/pull/75) Mike Nelson
+
+## 0.3.0.rc3 - 2014-09-02[YANKED]
+
+[Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.0.rc2...v0.3.0.rc3)
+
 ### Added
 - allow bypassing of stickiness
 
-## 0.3.0rc2 - 2014-08-05
+## 0.3.0.rc2 - 2014-08-05
 ### Added
 - add postgres specific tests.
 
@@ -13,7 +82,7 @@ All notable changes to this project will be documented in this file.
 - change using methods for matchers to be able to monkey patch them
 - follow AR naming conventions for adapter naming
 
-## 0.3.0rc1 - 2014-08-05
+## 0.3.0.rc1 - 2014-08-05
 ### Removed
 - removed initial connection logic. If a connection can't be made on startup, an error will be thrown rather than the node getting blacklisted.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,25 +72,25 @@ Fixed
 [Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.0.rc2...v0.3.0.rc3)
 
 Added
-- allow bypassing of stickiness
+- Allow bypassing of stickiness
 
 ## 0.3.0.rc2 - 2014-08-05
 Added
-- add postgres specific tests.
+- Add postgres specific tests.
 
 Changed
-- change using methods for matchers to be able to monkey patch them
-- follow AR naming conventions for adapter naming
+- Change using methods for matchers to be able to monkey patch them.
+- Follow AR naming conventions for adapter naming.
 
 ## 0.3.0.rc1 - 2014-08-05
 Removed
-- removed initial connection logic. If a connection can't be made on startup, an error will be thrown rather than the node getting blacklisted.
+- Remove initial connection logic. If a connection can't be made on startup, an error will be thrown rather than the node getting blacklisted.
 
 
 ## 0.2.2 - 2014-04-03
 Added
-- add logging of makara operations via the Makara::Logger
+- Add logging of makara operations via the Makara::Logger.
 
 Changed
-- begin tracing the series of errors associated with blacklisting rather than just the last. This becomes apparent in error messages.
-- fix Rails.cache usage when full environment is not loaded.
+- Begin tracing the series of errors associated with blacklisting rather than just the last. This becomes apparent in error messages.
+- Fix Rails.cache usage when full environment is not loaded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 [Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.4.rc1...v0.3.5)
 
-### Changed
+Changed
 
 - Raise `Makara::Errors::AllConnectionsBlacklisted` on timeout. [#104](https://github.com/taskrabbit/makara/pull/104) Brian Leonard
 
@@ -13,11 +13,11 @@ All notable changes to this project will be documented in this file.
 
 [Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.3...v0.3.4.rc1)
 
-### Added
+Added
 
 - Add `url` to database connections configurations. [#93](https://github.com/taskrabbit/makara/pull/93) Benjamin Fleischer
 
-### Changed
+Changed
 
 - Improve Postgresql compatibility and failover support, also fix [#78](https://github.com/taskrabbit/makara/issues/78), [#79](https://github.com/taskrabbit/makara/issues/79). [#87](https://github.com/taskrabbit/makara/pull/87) Vlad
 - Update README: Specify newrelic_rpm gem versions that will have the performance issue. [#95](https://github.com/taskrabbit/makara/pull/95) Benjamin Fleischer
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 [Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.2...v0.3.3)
 
-### Changed
+Changed
 
 - A context is local to the curent thread of execution. This will allow you to stick to master safely in a single thread
  +in systems such as sidekiq, for instance. Fix [#83](https://github.com/taskrabbit/makara/issues/83). [#84](https://github.com/taskrabbit/makara/pull/84) Matt Camuto
@@ -35,11 +35,11 @@ All notable changes to this project will be documented in this file.
 
 [Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.1...v0.3.2)
 
-### Fixed
+Fixed
 
 - Fix a `ArgumentError: not delegated` error for rails 3. [#82](https://github.com/taskrabbit/makara/pull/82) Eric Saxby
 
-### Changed
+Changed
 
 - Switch log format from `:info` to `:error`. Mike Nelson
 
@@ -47,21 +47,21 @@ All notable changes to this project will be documented in this file.
 
 [Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.0...v0.3.1)
 
-### Changed
+Changed
 
 - Globally move to multiline matchers. Mike Nelson
 
-### Changed
+Changed
 
 ## v0.3.0 - 2015-04-27
 
 [Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.0.rc3...v0.3.0)
 
-### Changed
+Changed
 
 - Reduce logging noise by using [the same rules as ActiveRecord uses](https://github.com/rails/rails/blob/b06f64c3480cd389d14618540d62da4978918af0/activerecord/lib/active_record/log_subscriber.rb#L33). [#76](https://github.com/taskrabbit/makara/pull/76) Andrew Kane
 
-### Fixed
+Fixed
 
 - Fix an issue for postgres that would route all queries to master. [#72](https://github.com/taskrabbit/makara/pull/72) Kali Donovan
 - Fix an edge case which would cause SET operations to send to all connections([#70](https://github.com/taskrabbit/makara/issues/70)). [#80](https://github.com/taskrabbit/makara/pull/80) Michael Amor Righi
@@ -71,26 +71,26 @@ All notable changes to this project will be documented in this file.
 
 [Full Changelog](https://github.com/taskrabbit/makara/compare/v0.3.0.rc2...v0.3.0.rc3)
 
-### Added
+Added
 - allow bypassing of stickiness
 
 ## 0.3.0.rc2 - 2014-08-05
-### Added
+Added
 - add postgres specific tests.
 
-### Changed
+Changed
 - change using methods for matchers to be able to monkey patch them
 - follow AR naming conventions for adapter naming
 
 ## 0.3.0.rc1 - 2014-08-05
-### Removed
+Removed
 - removed initial connection logic. If a connection can't be made on startup, an error will be thrown rather than the node getting blacklisted.
 
 
 ## 0.2.2 - 2014-04-03
-### Added
+Added
 - add logging of makara operations via the Makara::Logger
 
-### Changed
+Changed
 - begin tracing the series of errors associated with blacklisting rather than just the last. This becomes apparent in error messages.
 - fix Rails.cache usage when full environment is not loaded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ Changed
 
 Changed
 
-- A context is local to the curent thread of execution. This will allow you to stick to master safely in a single thread
- +in systems such as sidekiq, for instance. Fix [#83](https://github.com/taskrabbit/makara/issues/83). [#84](https://github.com/taskrabbit/makara/pull/84) Matt Camuto
+- A context is local to the curent thread of execution. This will allow you to stick to master safely in a single thread in systems such as sidekiq, for instance. Fix [#83](https://github.com/taskrabbit/makara/issues/83). [#84](https://github.com/taskrabbit/makara/pull/84) Matt Camuto
 
 ## v0.3.2 - 2015-05-16
 


### PR DESCRIPTION
Found the CHANGELOG is outdated so took some time to added them from the commits: https://github.com/taskrabbit/makara/compare/v0.3.0.rc3...v0.3.5

Please feel free to pointing out if I've missed or misspelled anything, or any preferred format of CHANGELOG. :grin: 

---

I'm using `v0.3.0.rc3` in current project and [it's yanked](https://rubygems.org/gems/makara/versions) recently.. makara has been so great and helpful, and what it does is critical so feeling a bit nervous just hitting `bundle update` without knowing what's changed. Thanks to all the hard works from the author and other contributors, hope we could keep this CHANGELOG updated as well :smile: 
