### PR TITLE
Choubacha/add tests for polymorphic associations

### DIFF
--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -51,11 +51,21 @@ describe 'MakaraPostgreSQLAdapter' do
         end
       end
 
+      context 'when querying an aggregate' do
+        it 'should respect the transaction' do
+          User.transaction { User.count }
+        end
+      end
+
+      context 'when querying for a specific record' do
+        it 'should respect the transaction' do
+          User.transaction { User.find(1) }
+        end
+      end
+
       context 'when executing a query' do
         it 'should respect the transaction' do
-          ActiveRecord::Base.transaction do
-            connection.execute('SELECT 1')
-          end
+          User.transaction { connection.execute('SELECT 1') }
         end
       end
     end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,9 +1,9 @@
-ActiveRecord::Schema.define(:version => 20130628161227) do
-  create_table "users", :force => true do |t|
-    t.string   "name"
+ActiveRecord::Schema.define(version: 20130628161227) do
+  create_table :users, force: true do |t|
+    t.string   :name
   end
 
-  create_table :pictures, :force => true do |t|
+  create_table :pictures, force: true do |t|
     t.string  :name
     t.integer :imageable_id
     t.string  :imageable_type

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,7 +1,14 @@
 ActiveRecord::Schema.define(:version => 20130628161227) do
-
   create_table "users", :force => true do |t|
     t.string   "name"
   end
 
+  create_table :pictures, :force => true do |t|
+    t.string  :name
+    t.integer :imageable_id
+    t.string  :imageable_type
+    t.timestamps null: false
+  end
+
+  add_index :pictures, :imageable_id
 end


### PR DESCRIPTION
FYI: This should have failing tests for the postgresql adapter.

Added specs that reproduce an issue facing transactions. Once a transaction has been opened it would make sense to stick to master for the duration of the transaction. Otherwise selects will not be able to see any of the just updated or inserted or deleted records. It should be noted that tests surrounding the find or count method **do** pass.

If `sticky: false` is set in the database.yml then executes and polymorphic associations appear to hit the slave.
