### PR TITLE
pass class reference to middleware builder

### DIFF
--- a/lib/makara/railtie.rb
+++ b/lib/makara/railtie.rb
@@ -1,7 +1,7 @@
 module Makara
   class Railtie < ::Rails::Railtie
 
-    config.app_middleware.use 'Makara::Middleware'
+    config.app_middleware.use Makara::Middleware
 
 
     initializer "makara.initialize_logger" do |app|


### PR DESCRIPTION
Passing strings or symbols to the middleware builder is deprecated
