### PR TITLE
Add support for ActiveSupport notifications

### DIFF
--- a/lib/makara/cache.rb
+++ b/lib/makara/cache.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/object/try'
+require 'active_support/notifications'
 
 # The Makara Cache should have access to your centralized cache store.
 # It serves the purpose of storing the Makara::Context across requests, servers, etc.
@@ -16,10 +17,13 @@ module Makara
       end
 
       def read(key)
+        ActiveSupport::Notifications.instrument('makara.cache.read', { key: key })
         store.try(:read, key)
       end
 
       def write(key, value, ttl)
+        payload = { key: key, value: value, ttl: ttl.to_i }
+        ActiveSupport::Notifications.instrument('makara.cache.write', payload)
         store.try(:write, key, value, :expires_in => ttl.to_i)
       end
 

--- a/lib/makara/context.rb
+++ b/lib/makara/context.rb
@@ -1,4 +1,5 @@
 require 'digest/md5'
+require 'active_support/notifications'
 
 # Keeps track of the current and previous context (hexdigests)
 # If a new context is needed it can be generated via Makara::Context.generate
@@ -13,19 +14,25 @@ module Makara
       end
 
       def get_previous
-        get_current_thread_local_for(:makara_context_previous)
+        get_current_thread_local_for(:makara_context_previous).tap do |context|
+          ActiveSupport::Notifications.instrument('makara.context.get_previous', context: context)
+        end
       end
 
       def set_previous(context)
-        set_current_thread_local(:makara_context_previous,context)
+        ActiveSupport::Notifications.instrument('makara.context.set_previous', context: context)
+        set_current_thread_local(:makara_context_previous, context)
       end
 
       def get_current
-        get_current_thread_local_for(:makara_context_current)
+        get_current_thread_local_for(:makara_context_current).tap do |context|
+          ActiveSupport::Notifications.instrument('makara.context.get_current', context: context)
+        end
       end
 
       def set_current(context)
-        set_current_thread_local(:makara_context_current,context)
+        ActiveSupport::Notifications.instrument('makara.context.set_current', context: context)
+        set_current_thread_local(:makara_context_current, context)
       end
 
       protected

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -2,6 +2,7 @@ require 'delegate'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/notifications'
 
 # The entry point of Makara. It contains a master and slave pool which are chosen based on the invocation
 # being proxied. Makara::Proxy implementations should declare which methods they are hijacking via the
@@ -189,10 +190,12 @@ module Makara
       # the args provided absolutely need master
       if needs_master?(method_name, args)
         stick_to_master(method_name, args)
+        ActiveSupport::Notifications.instrument('makara.pool.master')
         @master_pool
 
       # in this context, we've already stuck to master
       elsif Makara::Context.get_current == @master_context
+        ActiveSupport::Notifications.instrument('makara.pool.master')
         @master_pool
 
       # the previous context stuck us to master
@@ -201,21 +204,26 @@ module Makara
         # we're only on master because of the previous context so
         # behave like we're sticking to master but store the current context
         stick_to_master(method_name, args, false)
+        ActiveSupport::Notifications.instrument('makara.pool.master')
         @master_pool
 
       # all slaves are down (or empty)
       elsif @slave_pool.completely_blacklisted?
         stick_to_master(method_name, args)
+        ActiveSupport::Notifications.instrument('makara.pool.master')
         @master_pool
 
       # yay! use a slave
       else
+        ActiveSupport::Notifications.instrument('makara.pool.slave')
         @slave_pool
       end
     end
 
     # do these args require a master connection
     def needs_master?(method_name, args)
+      payload = { method: method_name, args: args }
+      ActiveSupport::Notifications.instrument('makara.proxy.needs_master', payload)
       true
     end
 
@@ -223,8 +231,10 @@ module Makara
     def hijacked
       @hijacked = true
       yield
+      ActiveSupport::Notifications.instrument('makara.proxy.hijacked', true)
     ensure
       @hijacked = false
+      ActiveSupport::Notifications.instrument('makara.proxy.hijacked', false)
     end
 
 
@@ -235,6 +245,9 @@ module Makara
 
 
     def stick_to_master(method_name, args, write_to_cache = true)
+      payload = {method: method_name, args: args, write_to_cache: write_to_cache }
+      ActiveSupport::Notifications.instrument('makara.proxy.stick_to_master', payload)
+
       # if we're already stuck to master, don't bother doing it again
       return if @master_context == Makara::Context.get_current
 


### PR DESCRIPTION
In taskrabbit/makara#103 an attempt was made to implement a bunch of
DTrace probes to monitor makara. Unfortunately, DTrace isn't something
most Rails developers are familiar with so the adoption of this might be
difficult to get off the ground. Here I've swapped the DTrace probes to
use ActiveSupport notifications which you are able to subscribe to
(usually within an initializer) and can offload to the monitoring tool
of your choose without needing to touch the library itself. For example:

```
# config/initializers/makara_instrumentation.rb
ActiveSupport::Notifications.subscribe(/makara/) do |*args|
  # .. do something with args
end
```

Will allow you to capture all makara events and perform additional calls
or monitoring on anything you deem important. If you are only interested
in a subset of the events, you can do that too.

```
# config/initializers/makara_instrumentation.rb
ActiveSupport::Notifications.subscribe('makara.proxy') do |*args|
  # .. do something with args on 'makara.proxy' events
end
```

Some specs for this new functionality to follow.
