### PR TITLE
Make makara error base class that inherits active record error class

### DIFF
--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -12,6 +12,7 @@ module Makara
   autoload :Proxy,              'makara/proxy'
 
   module Errors
+    autoload :MakaraError,                'makara/errors/makara_error'
     autoload :AllConnectionsBlacklisted,  'makara/errors/all_connections_blacklisted'
     autoload :BlacklistConnection,        'makara/errors/blacklist_connection'
     autoload :NoConnectionsAvailable,     'makara/errors/no_connections_available'

--- a/lib/makara/error_handler.rb
+++ b/lib/makara/error_handler.rb
@@ -11,7 +11,7 @@ module Makara
 
     rescue Exception => e
 
-      if e.class.name =~ /^Makara::/
+      if e.is_a?(Makara::Errors::MakaraError)
         harshly(e)
       else
         gracefully(connection, e)

--- a/lib/makara/errors/all_connections_blacklisted.rb
+++ b/lib/makara/errors/all_connections_blacklisted.rb
@@ -1,6 +1,6 @@
 module Makara
   module Errors
-    class AllConnectionsBlacklisted < StandardError
+    class AllConnectionsBlacklisted < MakaraError
 
       def initialize(pool, errors)
         errors = [*errors]

--- a/lib/makara/errors/blacklist_connection.rb
+++ b/lib/makara/errors/blacklist_connection.rb
@@ -1,6 +1,6 @@
 module Makara
   module Errors
-    class BlacklistConnection < ::StandardError
+    class BlacklistConnection < MakaraError
 
       attr_reader :original_error
 

--- a/lib/makara/errors/makara_error.rb
+++ b/lib/makara/errors/makara_error.rb
@@ -1,0 +1,7 @@
+module Makara
+  module Errors
+    class MakaraError < ::ActiveRecord::ActiveRecordError
+
+    end
+  end
+end

--- a/lib/makara/errors/no_connections_available.rb
+++ b/lib/makara/errors/no_connections_available.rb
@@ -1,6 +1,6 @@
 module Makara
   module Errors
-    class NoConnectionsAvailable < ::StandardError
+    class NoConnectionsAvailable < MakaraError
 
       attr_reader :role
 


### PR DESCRIPTION
We noticed that Makara was raising exceptions that inherit from StandardError.  We thought it might be a better pattern for Makara to have its own error class that each error inherits from, and then for Makara's base error to inherit from an ActiveRecord error.  I chose the lowest level one assuming it is minimally acceptable.

Now code that was

``` ruby
rescue StandardError => e
  if e.class.name =~ /^Makara::/
```

can be

``` ruby
rescue Makara::Errors::MakaraError
```
