### PR TITLE
Addressing the Rails 5 Question

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ gemfile:
   - gemfiles/ar40.gemfile
   - gemfiles/ar41.gemfile
   - gemfiles/ar42.gemfile
+  - Gemfile
 
 sudo: false
 

--- a/makara.gemspec
+++ b/makara.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Makara::VERSION
 
-  gem.add_dependency 'activerecord', '>= 3.0.0'
+  gem.add_dependency 'activerecord', '>= 3.0.0', '< 5.0.0'
 end


### PR DESCRIPTION
On a fresh checkout of makara, bundler will attempt to install the latest version of ActiveRecord (currently > 5.0), but this will fail because the default ruby version (in `.ruby-version`) is too low. 
