### PR TITLE
Use a float for master stickiness

### DIFF
--- a/lib/makara/cache.rb
+++ b/lib/makara/cache.rb
@@ -20,7 +20,7 @@ module Makara
       end
 
       def write(key, value, ttl)
-        store.try(:write, key, value, :expires_in => ttl.to_i)
+        store.try(:write, key, value, :expires_in => ttl.to_f)
       end
 
       protected

--- a/lib/makara/cache/memory_store.rb
+++ b/lib/makara/cache/memory_store.rb
@@ -13,14 +13,14 @@ module Makara
 
       def write(key, value, options = {})
         clean
-        @data[key] = [value, Time.now.to_i + (options[:expires_in] || 5).to_i]
+        @data[key] = [value, Time.now.to_f + (options[:expires_in] || 5).to_f]
         true
       end
 
       protected
 
       def clean
-        @data.delete_if{|k,v| v[1] <= Time.now.to_i }
+        @data.delete_if{|k,v| v[1] <= Time.now.to_f }
       end
 
     end


### PR DESCRIPTION
This allows for < 1s stickiness, useful if you're using a database engine such as AWS Aurora which can routinely achieve lower than 1s replication delay.