### PR TITLE
Rails 5.1 compat: coerce Relation arg to SQL string before matching against it

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -165,24 +165,33 @@ module ActiveRecord
 
 
       def should_stick?(method_name, args)
-        sql = args.first.to_s
+        sql = coerce_query_to_sql_string(args.first)
         return false if sql_skip_stickiness_matchers.any?{|m| sql =~ m }
         super
       end
 
 
       def needed_by_all?(method_name, args)
-        sql = args.first.to_s
+        sql = coerce_query_to_sql_string(args.first)
         return true if sql_all_matchers.any?{|m| sql =~ m }
         false
       end
 
 
       def needs_master?(method_name, args)
-        sql = args.first.to_s
+        sql = coerce_query_to_sql_string(args.first)
         return true if sql_master_matchers.any?{|m| sql =~ m }
         return false if sql_slave_matchers.any?{|m| sql =~ m }
         true
+      end
+
+
+      def coerce_query_to_sql_string(sql_or_arel)
+        if sql_or_arel.respond_to?(:to_sql)
+          sql_or_arel.to_sql
+        else
+          sql_or_arel.to_s
+        end
       end
 
 


### PR DESCRIPTION
Makara hijacks `select_rows` and inspects the first argument, expecting
it to be a SQL string, to determine whether to route to primary or
replica connection.

In https://github.com/rails/rails/pull/25522 the method signature
changed to take an Arel relation instead of a SQL string, so all queries
will go to the primary database and none to the replica.

To fix, we'll need to either expect & duly inspect the Relation or call
`#to_sql` before checking. The first will take more code and possibly
introduce bugs; the second will mean a perf hit due to converting every
relation to SQL twice.

Fixes #149.