### PR TITLE
Fix handling of blacklisting with frozen time.

### DIFF
--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -37,7 +37,7 @@ module Makara
 
     # has this node been blacklisted?
     def _makara_blacklisted?
-      @blacklisted_until.to_i > Time.now.to_i
+      @blacklisted_until.present? && @blacklisted_until.to_i > Time.now.to_i
     end
 
     # blacklist this node for @config[:blacklist_duration] seconds

--- a/spec/connection_wrapper_spec.rb
+++ b/spec/connection_wrapper_spec.rb
@@ -22,12 +22,19 @@ describe Makara::ConnectionWrapper do
     expect(subject._makara_weight).to eq(1)
   end
 
-  it 'should store the blacklist status' do
-    expect(subject._makara_blacklisted?).to eq(false)
-    subject._makara_blacklist!
-    expect(subject._makara_blacklisted?).to eq(true)
-    subject._makara_whitelist!
-    expect(subject._makara_blacklisted?).to eq(false)
-  end
+  context '#_makara_blacklisted?' do
+    it 'should store the blacklist status' do
+      expect(subject._makara_blacklisted?).to eq(false)
+      subject._makara_blacklist!
+      expect(subject._makara_blacklisted?).to eq(true)
+      subject._makara_whitelist!
+      expect(subject._makara_blacklisted?).to eq(false)
+    end
 
+    it 'should handle frozen pre-epoch dates' do
+      Timecop.freeze(Date.new(1900)) do
+        expect(subject._makara_blacklisted?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
For frozen pre-epoch dates (< 1970), we were incorrectly assuming the
node was blacklisted since `Time.now.to_i` would be a negative number.
Instead, explicitly check if a `blacklisted_until` value was set before
doing a time range comparison.