### PR TITLE
only check cache for "previously stuck to master" once per context

### DIFF
--- a/lib/makara/context.rb
+++ b/lib/makara/context.rb
@@ -13,15 +13,24 @@ module Makara
       end
 
       def get_previous
-        get_current_thread_local_for(:makara_context_previous)
+        get_current_thread_local_context_for(:makara_context_previous)
       end
 
       def set_previous(context)
+        set_current_thread_local(:makara_checked_previous,false)
         set_current_thread_local(:makara_context_previous,context)
       end
 
+      def checked_previous?
+        get_current_thread_local_for(:makara_checked_previous)
+      end
+
+      def set_checked_previous
+        set_current_thread_local(:makara_checked_previous,true)
+      end
+
       def get_current
-        get_current_thread_local_for(:makara_context_current)
+        get_current_thread_local_context_for(:makara_context_current)
       end
 
       def set_current(context)
@@ -32,7 +41,11 @@ module Makara
 
       def get_current_thread_local_for(type)
         t = Thread.current
-        current = t.respond_to?(:thread_variable_get) ? t.thread_variable_get(type) : t[type]
+        t.respond_to?(:thread_variable_get) ? t.thread_variable_get(type) : t[type]
+      end
+
+      def get_current_thread_local_context_for(type)
+        current = get_current_thread_local_for(type)
         current ||= set_current_thread_local(type,generate)
       end
 

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -80,10 +80,10 @@ module Makara
     def strategy_for(role)
       strategy_name = @config_parser.makara_config["#{role}_strategy".to_sym]
       case strategy_name
-      when 'round_robin', 'roundrobin', nil, ''
-        strategy_name = "::Makara::Strategies::RoundRobin"
-      when 'failover'
-        strategy_name = "::Makara::Strategies::PriorityFailover"
+        when 'round_robin', 'roundrobin', nil, ''
+          strategy_name = "::Makara::Strategies::RoundRobin"
+        when 'failover'
+          strategy_name = "::Makara::Strategies::PriorityFailover"
       end
       strategy_name.constantize.new(self)
     end
@@ -197,9 +197,11 @@ module Makara
       # in this context, we've already stuck to master
       elsif Makara::Context.get_current == @master_context
         @master_pool
-
-      # the previous context stuck us to master
-      elsif previously_stuck_to_master?
+        
+      # check if the previous context stuck us to master, if we haven't already checked for this thread.
+      # if we weren't previously stuck to master, we don't need to keep checking with each DB request.
+      elsif !Makara::Context.checked_previous? && previously_stuck_to_master?
+        Makara::Context.set_checked_previous
 
         # we're only on master because of the previous context so
         # behave like we're sticking to master but store the current context

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -242,7 +242,7 @@ module Makara
 
     def previously_stuck_to_master?
       return false unless @sticky
-      Makara::Context.get_cached_previous(@id)
+      Makara::Context.cached_previous?(@id)
     end
 
 

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -102,15 +102,52 @@ describe Makara::Context do
       expect(uniq_curret_contexts.uniq.count).to eq(3)
     end
 
-    it 'sets thread local variable makara_checked_previous to false' do
-      Makara::Context.set_checked_previous
-      expect(Makara::Context.checked_previous?).to be true
+    it 'sets thread local variable makara_cached_previous to nil' do
+      t = Thread.current
+      t.respond_to?(:thread_variable_set) ? t.thread_variable_set(:makara_cached_previous,1) : t[:makara_cached_previous]=1
 
       Makara::Context.set_previous("val")
 
-      expect(Makara::Context.checked_previous?).to be false
+      thread_var = t.respond_to?(:thread_variable_get) ? t.thread_variable_get(:makara_cached_previous) : t[:makara_cached_previous]
+      expect(thread_var).to be nil
     end
   end
 
+  describe 'cache_current' do
+    it 'caches the current context using Makara::Cache' do
+      context = 'some_val'
+      config_id = 1
+      ttl = 10
+      Makara::Cache.store = :memory
+      allow(Makara::Context).to receive(:get_current) { context }
+
+      # expect it to not be set yet
+      expect(Makara::Cache.read("makara::#{context}-#{config_id}")).to eq(nil)
+
+      Makara::Context.cache_current(config_id, ttl)
+      # expect it to be set now
+      expect(Makara::Cache.read("makara::#{context}-#{config_id}")).to eq('1')
+    end
+  end
+
+  describe 'cached_previous?' do
+    it 'gets the context that was cached via cache_current' do
+      context = 'some_val'
+      config_id = 1
+      ttl = 10
+      Makara::Cache.store = :memory
+
+      # this emulates handling a web request, which gets stuck to master, and therefore stores the current context in cache
+      allow(Makara::Context).to receive(:get_current) { context }
+      Makara::Context.cache_current(config_id, ttl)
+
+      # this emulates handling a subsequent web request, which included a cookie that is the context from the last request,
+      # i.e., now that is considered the "previous" context
+      allow(Makara::Context).to receive(:get_previous) { context }
+      cached_context =  Makara::Context.cached_previous?(config_id)
+
+      expect(cached_context).to eq(true)
+    end
+  end
 end
 

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -101,6 +101,15 @@ describe Makara::Context do
       threads.map(&:join)
       expect(uniq_curret_contexts.uniq.count).to eq(3)
     end
+
+    it 'sets thread local variable makara_checked_previous to false' do
+      Makara::Context.set_checked_previous
+      expect(Makara::Context.checked_previous?).to be true
+
+      Makara::Context.set_previous("val")
+
+      expect(Makara::Context.checked_previous?).to be false
+    end
   end
 
 end


### PR DESCRIPTION
Hi TaskRabbit people, I'd like to propose this change to help reduce usage of the context cache.

We use makara in a master-slave, multi-app server rails environment.  We use redis for centralized caching and for Rails.cache.  We noticed that over 90% of the commands processed by our redis master are for makara contexts.

Looking through makara code, and debugging, I found that in _appropriate_pool in proxy.rb, if the current context is NOT master, then every DB request during the processing of a single web request calls previously_stuck_to_master, which queries redis (in our case).  A lot of our web requests are page loads that do a lot (say, 40+) DB requests, so it also hits redis 40+ times.

However, during handling a web request, previously_stuck_to_master is either true or false as of the first use of _appropriate_pool, and it won't (and can't) change during the handling of that web request.  So it would be much more efficient to just check previously_stuck_to_master once.  If previously_stuck_to_master returns true, then the current context is switched to master, and any subsequent _appropriate_pool calls will use master because current == master (this is existing behaviour).

It's a bit convoluted to try to explain but hopefully that makes sense.

The fix I made just uses a thread local var to track whether the previous context has been checked yet or not.  It is set to false when Makara::Context.set_previous is called (it's called via middleware.rb before handling a web request), and then it is set to true in _appropriate_pool after previously_stuck_to_master is called.

If you want to change the method names or signatures I added, feel free, or let me know and I'll change them.

Thanks!
Greg Patrick - greg.patrick@varsitytutors.com