### PR TITLE
Context: thread-local cache for previous context stickiness

### DIFF
--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,6 +1,8 @@
 ActiveRecord::Schema.define(:version => 20130628161227) do
 
-  create_table "users", :force => true do |t|
+  drop_table "users" if table_exists? "users"
+
+  create_table "users" do |t|
     t.string   "name"
   end
 


### PR DESCRIPTION
* Fix that previous-stickiness check was cached for all configs
* Check Ruby Thread capabilities once rather than at runtime
* Choose thread-local get/set strategy once when we define the fetch/set methods rather than on every method call.
    
References ae2be27016b8866b6d9f86b6e1ad5699abd84f7a and #156