### PR TITLE
Fixes `can't add a new key into hash during iteration` error

### DIFF
--- a/lib/makara/cache/memory_store.rb
+++ b/lib/makara/cache/memory_store.rb
@@ -4,6 +4,7 @@ module Makara
 
       def initialize
         @data = {}
+        @mutex = Mutex.new
       end
 
       def read(key)
@@ -20,7 +21,9 @@ module Makara
       protected
 
       def clean
-        @data.delete_if{|k,v| v[1] <= Time.now.to_i }
+        @mutex.synchronize do
+          @data.delete_if{|k,v| v[1] <= Time.now.to_i }
+        end
       end
 
     end

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -52,6 +52,28 @@ describe Makara::Cache do
       expect(data).not_to have_key('test')
     end
 
+    it 'has thread-safety' do
+      store = Makara::Cache::MemoryStore.new
+      previous_value = Thread.abort_on_exception
+
+      begin
+        Thread.abort_on_exception = true
+
+        workers = 2.times.map do
+          Thread.new do
+            100.times do |n|
+              store.write(n, 'value', expires_in: 0.5)
+              sleep(0.01)
+            end
+          end
+        end
+
+        expect { workers.map(&:join) }.to_not raise_error
+      ensure
+        Thread.abort_on_exception = previous_value
+      end
+    end
+
   end
 
 


### PR DESCRIPTION
This adds thread-safety to the `MemoryStore`. Here's code to reproduce the current issue.

```ruby
Thread.abort_on_exception = true

$store = Makara::Cache::MemoryStore.new

workers = 10.times.map do
  Thread.new do
    loop do
      $store.write(rand(100), true, expires_in: 1)
      sleep(rand / 100)
    end
  end
end

workers.map(&:join)
```