### PR TITLE
add an option to skip process around context

### DIFF
--- a/lib/makara/context.rb
+++ b/lib/makara/context.rb
@@ -7,6 +7,10 @@ module Makara
   class Context
     class << self
 
+      @skip_context_process = false
+
+      attr_accessor :skip_context_process
+
       def generate(seed = nil)
         seed ||= "#{Time.now.to_i}#{Thread.current.object_id}#{rand(99999)}"
         Digest::MD5.hexdigest(seed)

--- a/lib/makara/middleware.rb
+++ b/lib/makara/middleware.rb
@@ -24,7 +24,7 @@ module Makara
 
     def call(env)
 
-      return @app.call(env) if ignore_request?(env)
+      return @app.call(env) if Makarara::Context.skip_context_process || ignore_request?(env)
 
       Makara::Context.set_previous previous_context(env)
       Makara::Context.set_current new_context(env)

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -77,6 +77,13 @@ describe Makara::Middleware do
     expect(curr2).to eq(Makara::Context.get_current)
   end
 
+  it 'skip process if Makara::Context.skip_context_process set to true' do
+    allow(Makara::Context).to receive(:skip_context_process).and_return(true)
+    middleware.call(env)
+    expect(Makara::Context).not_to receive(:set_previous)
+    expect(Makara::Context).not_to receive(:set_current)
+  end
+
   def context_from(response)
     response[2][0].split('-')
   end


### PR DESCRIPTION
This is a suggestion to make app more efficient for those who do not use context. 
You can skip processing around context by setting Makara::Context.skip_context_process.