### PR TITLE
Fix: an application freezes when a slave is down

### DIFF
--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -64,17 +64,14 @@ module Makara
       @connections.each do |con|
         next if con._makara_blacklisted?
         begin
-          if block
-            value = @proxy.error_handler.handle(con) do
+          ret = @proxy.error_handler.handle(con) do
+            if block
               yield con
+            else
+              con.send(method, *args)
             end
           end
 
-          if method
-            ret = con.send(method, *args)
-          else
-            ret = value
-          end
           one_worked = true
         rescue Makara::Errors::BlacklistConnection => e
           errors.insert(0, e)


### PR DESCRIPTION
I get a freeze application (Rails 5.1.4, ActiveRecord 5.1.4) when slave is down with infinitive count of requests like:
```
SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci,  @@SESSION.sql_mode = 'TRADITIONAL',  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
```

config:
```
  makara:
    sticky: false
    master_strategy: failover
    slave_strategy: failover

    connections:
      - role: master
        host: <%= SENV['MYSQL_HOST_MASTER'] %>
        disable_blacklist: true
      - role: slave
        host: <%= SENV['MYSQL_HOST_SLAVE'] %>
        blacklist_duration: 60
      - role: slave
        host: <%= SENV['MYSQL_HOST_MASTER'] %>
        disable_blacklist: true
```

It happens when line `con.send(method, *args)` raises an error `Can't connect to MySQL server` but nothing handles it