### PR TITLE
Don't raise AllConnectionsBlacklisted when slave comes back

### DIFF
--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -57,6 +57,8 @@ module Makara
     # send this method to all available nodes
     # send nil to just yield with each con if there is block
     def send_to_all(method, *args, &block)
+      return if @disabled
+
       ret = nil
       one_worked = false # actually found one that worked
       errors = []
@@ -79,13 +81,7 @@ module Makara
         end
       end
 
-      if !one_worked
-        if connection_made?
-          raise Makara::Errors::AllConnectionsBlacklisted.new(self, errors)
-        else
-          raise Makara::Errors::NoConnectionsAvailable.new(@role) unless @disabled
-        end
-      end
+      raise Makara::Errors::NoConnectionsAvailable.new(@role) unless one_worked
 
       ret
     end


### PR DESCRIPTION
- Mysql 5.7.17
- Rails 5.1.4
- Makara 0.3.9
- Ruby 2.3.0p

database.yml:
```
base: &base
  adapter: mysql2_makara
  encoding: utf8mb4
  collation: utf8mb4_unicode_ci
  reconnect: true
  pool: 15
  username: <%= SENV['MYSQL_USER'] %>
  password: <%= SENV['MYSQL_PASSWORD'] %>
  database: <%= SENV['MYSQL_DATABASE'] %>
  variables: # https://github.com/rails/rails/issues/25924
    sql_mode: TRADITIONAL

  makara:
    sticky: false
    master_strategy: failover
    slave_strategy: failover
    connection_error_matchers:
      - '/Server shutdown in progress/' # Do not fail on reboot
      - '/Unknown MySQL server host/' # Can be thrown on replica re-creation
    connect_timeout: 1

    connections:
      - role: master
        host: master.host
        port: 3307
        sticky: true
        disable_blacklist: true
      - role: slave
        host: slave.host
        port: 3308
        blacklist_duration: 60
```

Old behavior:
- when all `slaves` are down Makara uses `master`
- when one slave comes back Makara raises the exception `AllConnectionsBlacklisted` for the first request