### PR TITLE
Allow SELECTs that use common table expressions to go to replicas

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -109,7 +109,7 @@ module ActiveRecord
       send_to_all :connect, :reconnect!, :verify!, :clear_cache!, :reset!
 
       SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval)\(/i].map(&:freeze).freeze
-      SQL_SLAVE_MATCHERS            = [/\A\s*select\s/i].map(&:freeze).freeze
+      SQL_SLAVE_MATCHERS            = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
       SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
       SQL_SKIP_STICKINESS_MATCHERS  = [/\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
 

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -30,7 +30,9 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     'select * from users where name = "lock in share mode"' => false,
     'select nextval(\'users_id_seq\')' => true,
     'select currval(\'users_id_seq\')' => true,
-    'select lastval()' => true
+    'select lastval()' => true,
+    'with fence as (select * from users) select * from fence' => false,
+    'with fence as (select * from felines) insert to cats' => true
   }.each do |sql, should_go_to_master|
 
     it "determines that \"#{sql}\" #{should_go_to_master ? 'requires' : 'does not require'} master" do


### PR DESCRIPTION
Formula is `WITH` followed by `) SELECT`. Most CTEs will have a SELECT somewhere in the query, but only if it's the last one should it be preceded by a right parenthesis (and optional whitespace).