### PR TITLE
Rollback not finished transactions

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -42,7 +42,7 @@ module ActiveRecord
           when *harsh_errors
             harshly(e)
           else
-            if connection_message?(e) || custom_error_message?(connection, e)
+            if !connection.in_transaction? && (connection_message?(e) || custom_error_message?(connection, e))
               gracefully(connection, e)
             else
               harshly(e)

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -102,6 +102,13 @@ module Makara
       end
     end
 
+    def in_transaction?
+      if @connection.respond_to?(:open_transactions)
+        @connection.open_transactions > 0
+      else
+        false
+      end
+    end
 
     class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
       def respond_to#{RUBY_VERSION.to_s =~ /^1.8/ ? nil : '_missing'}?(m, include_private = false)


### PR DESCRIPTION
Makara gracefully handles exceptions, in the result, it does not rollback transactions on a master when the master goes into reboot/down. This PR should fix it.