### PR TITLE
Fix loading fixtures in Rails 5.2

### DIFF
--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -146,10 +146,10 @@ module Makara
       # The new definition should allow for the proxy to intercept the invocation if required.
       @proxy.class.hijack_methods.each do |meth|
         extension << %Q{
-          def #{meth}(*args)
+          def #{meth}(*args, &block)
             _makara_hijack do |proxy|
               if proxy
-                proxy.#{meth}(*args)
+                proxy.#{meth}(*args, &block)
               else
                 super
               end

--- a/spec/connection_wrapper_spec.rb
+++ b/spec/connection_wrapper_spec.rb
@@ -14,8 +14,11 @@ describe Makara::ConnectionWrapper do
   end
 
   it 'should invoke hijacked methods on the proxy when invoked directly' do
-    expect(proxy).to receive(:execute).with('test').once
-    connection.execute("test")
+    expect(proxy).to receive(:execute).with('test').once do |&block|
+      expect(block.call).to eq('Hello')
+    end
+
+    connection.execute('test') { 'Hello' }
   end
 
   it 'should have a default weight of 1' do


### PR DESCRIPTION
Preserve blocks when delegating `ConnectionWrapper` methods to `Proxy`. Rails’s newly-optimized fixture loading code calls `#transaction` from within a connection adapter method, exercising this code path. Without this fix, we get a `LocalJumpError` because `#transaction` expects a block.

/cc @jeremy @rosa