### PR TITLE
Send advisory lock requests to the master

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -108,7 +108,7 @@ module ActiveRecord
       hijack_method :execute, :select_rows, :exec_query, :transaction
       send_to_all :connect, :reconnect!, :verify!, :clear_cache!, :reset!
 
-      SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval)\(/i].map(&:freeze).freeze
+      SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
       SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
       SQL_SKIP_STICKINESS_MATCHERS  = [/\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -32,7 +32,11 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     'select currval(\'users_id_seq\')' => true,
     'select lastval()' => true,
     'with fence as (select * from users) select * from fence' => false,
-    'with fence as (select * from felines) insert to cats' => true
+    'with fence as (select * from felines) insert to cats' => true,
+    'select get_lock(\'foo\', 0)' => true,
+    'select release_lock(\'foo\')' => true,
+    'select pg_advisory_lock(12345)' => true,
+    'select pg_advisory_unlock(12345)' => true
   }.each do |sql, should_go_to_master|
 
     it "determines that \"#{sql}\" #{should_go_to_master ? 'requires' : 'does not require'} master" do


### PR DESCRIPTION
Fixes running migrations in Rails 5.2, which takes an advisory lock on a replica connection and attempts to release it on the primary connection:

```
[replica] (0.1ms)  SELECT GET_LOCK('5059312551837065865', 0)
[replica] (0.4ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
Migrating to IndexRemindersOnDeliveredAndRemindAt (20180301142256)
[primary] (29.2ms)  CREATE  INDEX `index_reminders_on_delivered_and_remind_at`  ON `reminders` (`delivered`, `remind_at`) 
[primary] (0.3ms)  BEGIN
[primary] ActiveRecord::SchemaMigration Create (0.6ms)  INSERT INTO `schema_migrations` (`version`) VALUES ('20180301142256')
[primary] (0.5ms)  COMMIT
[primary] ActiveRecord::InternalMetadata Load (0.3ms)  SELECT  `ar_internal_metadata`.* FROM `ar_internal_metadata` WHERE `ar_internal_metadata`.`key` = 'environment' LIMIT 1
[primary] (0.2ms)  BEGIN
[primary] (0.2ms)  COMMIT
[primary] (0.3ms)  SELECT RELEASE_LOCK('5059312551837065865')

Failed to release advisory lock
```