### PR TITLE
 Don’t try to connect to blacklisted resources 

### DIFF
--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -64,6 +64,7 @@ module Makara
     end
 
     def _makara_connection
+      return if _makara_blacklisted?
       current = @connection
 
       if current

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -64,7 +64,6 @@ module Makara
     end
 
     def _makara_connection
-      return if _makara_blacklisted?
       current = @connection
 
       if current

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -106,13 +106,10 @@ module Makara
 
         value
 
-      # if we've made any connections within this pool, we should report the blackout.
-      elsif connection_made?
+      else
         err = Makara::Errors::AllConnectionsBlacklisted.new(self, @blacklist_errors)
         @blacklist_errors = []
         raise err
-      else
-        raise Makara::Errors::NoConnectionsAvailable.new(@role) unless @disabled
       end
 
     # when a connection causes a blacklist error within the provided block, we blacklist it then retry
@@ -122,10 +119,7 @@ module Makara
       retry
     end
 
-
-
     protected
-
 
     # have we connected to any of the underlying connections.
     def connection_made?

--- a/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
@@ -163,7 +163,7 @@ describe 'MakaraMysql2Adapter' do
 
       allow_any_instance_of(Makara::Strategies::RoundRobin).to receive(:single_one?){ true }
       Test::User.exists? # flush other (schema) things that need to happen
-      
+
       con = connection.slave_pool.connections.first
       if (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR <= 0)
         expect(con).to receive(:execute).with(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/, any_args).once.and_call_original

--- a/spec/active_record/connection_adapters/makara_postgis_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgis_adapter_spec.rb
@@ -118,8 +118,8 @@ if RUBY_ENGINE == 'ruby' &&
         allow(ActiveRecord::Base).to receive(:postgis_connection).and_raise(StandardError.new('could not connect to server: Connection refused'))
 
         ActiveRecord::Base.establish_connection(config)
-        expect { connection.execute('SELECT * FROM users') }.to raise_error(Makara::Errors::NoConnectionsAvailable)
-        expect { connection.execute('INSERT INTO users (name) VALUES (\'John\')') }.to raise_error(Makara::Errors::NoConnectionsAvailable)
+        expect { connection.execute('SELECT * FROM users') }.to raise_error(Makara::Errors::AllConnectionsBlacklisted)
+        expect { connection.execute('INSERT INTO users (name) VALUES (\'John\')') }.to raise_error(Makara::Errors::AllConnectionsBlacklisted)
       end
     end
 
@@ -148,7 +148,7 @@ if RUBY_ENGINE == 'ruby' &&
         ActiveRecord::Base.establish_connection(custom_config)
 
         connection.execute('SELECT * FROM users')
-        expect { connection.execute('INSERT INTO users (name) VALUES (\'John\')') }.to raise_error(Makara::Errors::NoConnectionsAvailable)
+        expect { connection.execute('INSERT INTO users (name) VALUES (\'John\')') }.to raise_error(Makara::Errors::AllConnectionsBlacklisted)
       end
     end
   end

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -77,7 +77,7 @@ describe 'MakaraPostgreSQLAdapter' do
 
       allow_any_instance_of(Makara::Strategies::RoundRobin).to receive(:single_one?){ true }
       Test::User.exists? # flush other (schema) things that need to happen
-      
+
       con = connection.slave_pool.connections.first
       if (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 2) ||
          (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR <= 0)
@@ -100,8 +100,8 @@ describe 'MakaraPostgreSQLAdapter' do
       allow(ActiveRecord::Base).to receive(:postgresql_connection).and_raise(StandardError.new('could not connect to server: Connection refused'))
 
       ActiveRecord::Base.establish_connection(config)
-      expect { connection.execute('SELECT * FROM users') }.to raise_error(Makara::Errors::NoConnectionsAvailable)
-      expect { connection.execute('INSERT INTO users (name) VALUES (\'John\')') }.to raise_error(Makara::Errors::NoConnectionsAvailable)
+      expect { connection.execute('SELECT * FROM users') }.to raise_error(Makara::Errors::AllConnectionsBlacklisted)
+      expect { connection.execute('INSERT INTO users (name) VALUES (\'John\')') }.to raise_error(Makara::Errors::AllConnectionsBlacklisted)
     end
   end
 
@@ -130,7 +130,7 @@ describe 'MakaraPostgreSQLAdapter' do
       establish_connection(custom_config)
 
       connection.execute('SELECT * FROM users')
-      expect { connection.execute('INSERT INTO users (name) VALUES (\'John\')') }.to raise_error(Makara::Errors::NoConnectionsAvailable)
+      expect { connection.execute('INSERT INTO users (name) VALUES (\'John\')') }.to raise_error(Makara::Errors::AllConnectionsBlacklisted)
     end
   end
 


### PR DESCRIPTION
Hello! Here is the PR for not trying to connect to a blacklisted host.
Here is some background: 
When using makara with a master/slave setup and the master goes down, we would like to have the connection timeout and the master blacklisted for a period of time. Just handle reads from the slave and writes will fail. This is useful when AWS or other db providers decide to cycle machines; for instance applying meltdown patch. Another use case for this is to be able to resize your master db at any point without significant down time, assuming you are read heavy. We are 90% reads in this case and cannot go down for a db resize. We would like to continue reading from the slave and serving 90% of our requests. 

Our database.yml file looks like this with this patch:
```
development: &defaults
  adapter: postgresql_makara
  makara:
    blacklist_duration: 5
    master_ttl: 5
    master_strategy: round_robin
    sticky: true
    connections:
      - role: master
        url: postgresql://localhost:5432/app_dev?pool=15&timeout=500
      - role: slave
        url: postgresql://localhost:5433/app_dev?pool=15&timeout=500
    connection_error_matchers:
      - !ruby/regexp /invalid encoding name/
  encoding: unicode
  reconnect: true
  connect_timeout: 1
```
 The first request to hit the DB will take 1 second, for client connection timeout from postgres, plus the normal request time to return. The problem seems to occur when calling https://github.com/taskrabbit/makara/blob/master/lib/makara/pool.rb#L131 `connection_made?` That calls `_makara_connected?` which will call `_makara_connection` which will try to connect to the db even if it is blacklisted already. 