### PR TITLE
Using the AR adapter name notation for PostGIS adapter

### DIFF
--- a/lib/active_record/connection_adapters/postgis_makara_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_makara_adapter.rb
@@ -1,0 +1,36 @@
+require 'active_record/connection_adapters/makara_abstract_adapter'
+require 'active_record/connection_adapters/postgis_adapter'
+
+if ActiveRecord::VERSION::MAJOR >= 4
+  module ActiveRecord
+    module ConnectionHandling
+      def postgis_makara_connection(config)
+        ActiveRecord::ConnectionAdapters::PostgisMakaraAdapter.new(config)
+      end
+    end
+  end
+else
+  module ActiveRecord
+    class Base
+      def self.postgis_makara_connection(config)
+        ActiveRecord::ConnectionAdapters::PostgisMakaraAdapter.new(config)
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgisMakaraAdapter < ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter
+      def self.visitor_for(*args)
+        ActiveRecord::ConnectionAdapters::PostGISAdapter.visitor_for(*args)
+      end
+
+      protected
+
+      def active_record_connection_for(config)
+        ::ActiveRecord::Base.postgis_connection(config)
+      end
+    end
+  end
+end

--- a/spec/support/postgis_database.yml
+++ b/spec/support/postgis_database.yml
@@ -1,5 +1,5 @@
 test:
-  adapter: 'makara_postgis'
+  adapter: 'postgis_makara'
   database: 'makara_test'
   username: 'root'
   password: ''


### PR DESCRIPTION
This change is to align PostGIS adapter naming with other adapters.
Without this, the `rails dbconsole` command is failing for an existing `makara_postgis` as it expects adapter name to start with `postgis`
