### PR TITLE
Include more PG Advisory Lock statements to SQL_MASTER_MATCHERS

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -108,7 +108,7 @@ module ActiveRecord
       hijack_method :execute, :exec_query, :exec_no_cache, :exec_cache, :transaction
       send_to_all :connect, :reconnect!, :verify!, :clear_cache!, :reset!
 
-      SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
+      SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock|pg_advisory_xact_lock|pg_try_advisory_lock|pg_try_advisory_xact_lock)\(/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
       SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
       SQL_SKIP_STICKINESS_MATCHERS  = [/\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -36,7 +36,10 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     'select get_lock(\'foo\', 0)' => true,
     'select release_lock(\'foo\')' => true,
     'select pg_advisory_lock(12345)' => true,
-    'select pg_advisory_unlock(12345)' => true
+    'select pg_advisory_unlock(12345)' => true,
+    'select pg_advisory_xact_lock(12345)' => true,
+    'select pg_try_advisory_lock(12345)' => true,
+    'select pg_try_advisory_xact_lock(12345)' => true
   }.each do |sql, should_go_to_master|
 
     it "determines that \"#{sql}\" #{should_go_to_master ? 'requires' : 'does not require'} master" do


### PR DESCRIPTION
Add different types of PG advisory locks to the list of master only statements.

Here is the list of different advisory locks:
https://www.postgresql.org/docs/current/static/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS-TABLE