### PR TITLE
Add more metadata to gemspec

### DIFF
--- a/makara.gemspec
+++ b/makara.gemspec
@@ -7,6 +7,10 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Read-write split your DB yo}
   gem.summary       = %q{Read-write split your DB yo}
   gem.homepage      = ""
+  gem.licenses      = ['MIT']
+  gem.metadata      = {
+                        source_code_uri: 'https://github.com/taskrabbit/makara'
+                      }
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
When you regularly need to assess the licensing state of the open source libraries you are using, it is helpful to get as many connecting pieces as possible.

This pull request adds some nice-to-have metadata to the gemspec of makara:
* The license that makara uses, so it is immediately visible from rubygems.org
* A link to makara's source code, so that users can immediately find it when browsing rubygems.org

Note that all those information also also available from the rubygems.org API.