### PR TITLE
Add connection logging in non-Rails enviroments

### DIFF
--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'makara/version'
 require 'makara/railtie' if defined?(Rails)
 module Makara
@@ -30,4 +31,10 @@ module Makara
     autoload :PriorityFailover, 'makara/strategies/priority_failover'
   end
 
+end
+
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::LogSubscriber.log_subscribers.each do |subscriber|
+    subscriber.extend ::Makara::Logging::Subscriber
+  end
 end

--- a/lib/makara/railtie.rb
+++ b/lib/makara/railtie.rb
@@ -5,11 +5,5 @@ module Makara
       app.middleware.use Makara::Middleware
     end
 
-    initializer "makara.initialize_logger" do |app|
-      ActiveRecord::LogSubscriber.log_subscribers.each do |subscriber|
-        subscriber.extend ::Makara::Logging::Subscriber
-      end
-    end
-
   end
 end


### PR DESCRIPTION
Since connection logging just depends on ActiveRecord, it'd be great to add it even when Rails is not present.