### PR TITLE
ErrorHandler#harshly no longer fails when backtrace nil

### DIFF
--- a/lib/makara/error_handler.rb
+++ b/lib/makara/error_handler.rb
@@ -31,7 +31,7 @@ module Makara
 
 
     def harshly(e)
-      ::Makara::Logging::Logger.log("Harshly handling: #{e}\n#{e.backtrace.join("\n\t")}")
+      ::Makara::Logging::Logger.log("Harshly handling: #{e}\n#{e.backtrace&.join("\n\t")}")
       raise e
     end
 

--- a/spec/error_handler_spec.rb
+++ b/spec/error_handler_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe Makara::ErrorHandler do
+  let(:handler){ described_class.new }
+
+  before{ allow(::Makara::Logging::Logger).to receive(:log) }
+
+  describe "#harshly" do
+    subject{ handler.send(:harshly, error) }
+
+    context "an error with a backtrace" do
+      let(:error){ StandardError.new }
+
+      before do
+        error.set_backtrace(caller)
+        expect(error.backtrace).not_to be_nil
+      end
+
+      it "re-raises the original exception and logs with a backtrace" do
+        expect{ subject }.to raise_error(error)
+        expect(::Makara::Logging::Logger).to have_received(:log).with(/Harshly handling: StandardError\s+.+/i)
+      end
+    end
+
+    context "an error without a backtrace" do
+      let(:error){ StandardError.new }
+
+      before { expect(error.backtrace).to be_nil }
+
+      it "re-raises the original exception and logs without a backtrace" do
+        expect{ subject }.to raise_error(error)
+        expect(::Makara::Logging::Logger).to have_received(:log).with("Harshly handling: StandardError\n")
+      end
+
+    end
+  end
+
+end


### PR DESCRIPTION
When an exception doesn't have a `backtrace` (it is `nil`), the `harshly` method can blow up, masking the underlying exception with this instead:

```
NoMethodError: undefined method `join' for nil:NilClass
```

This PR updates the call to `join` to use the [safe navigation operator](https://en.wikipedia.org/wiki/Safe_navigation_operator#Ruby) which will result in the backtrace in the message being empty, and allowing `harshly` to re-raise the original exception as intended.