### PR TITLE
add github url for homepage

### DIFF
--- a/makara.gemspec
+++ b/makara.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@mikeonrails.com"]
   gem.description   = %q{Read-write split your DB yo}
   gem.summary       = %q{Read-write split your DB yo}
-  gem.homepage      = ""
+  gem.homepage      = "https://github.com/taskrabbit/makara"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
There isn't github link in the gem page (https://rubygems.org/gems/makara)
So when we want to know detail or changes on gem page, we should search this github page.

I think the github link is very good for gem's users.