### PR TITLE
SET LOCAL is only effective on master

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -112,6 +112,7 @@ module ActiveRecord
       SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
       SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
+      SQL_SKIP_ALL_MATCHERS         = [/\A\s*set\s+local\s/i].map(&:freeze).freeze
       SQL_SKIP_STICKINESS_MATCHERS  = [/\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
 
 
@@ -129,6 +130,9 @@ module ActiveRecord
         SQL_ALL_MATCHERS
       end
 
+      def sql_skip_all_matchers
+        SQL_SKIP_ALL_MATCHERS
+      end
 
       def sql_skip_stickiness_matchers
         SQL_SKIP_STICKINESS_MATCHERS
@@ -174,6 +178,7 @@ module ActiveRecord
 
       def needed_by_all?(method_name, args)
         sql = coerce_query_to_sql_string(args.first)
+        return false if sql_skip_all_matchers.any?{|m| sql =~ m }
         return true if sql_all_matchers.any?{|m| sql =~ m }
         false
       end


### PR DESCRIPTION
Transactions are not sent to all connections, so `SET LOCAL` is ignored on replicas and causes a warning message.

Reference: https://www.postgresql.org/docs/11/sql-set.html
