### PR TITLE
switch to master for setval on sequence

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -109,7 +109,7 @@ module ActiveRecord
       hijack_method :execute, :exec_query, :exec_no_cache, :exec_cache, :transaction
       send_to_all :connect, :reconnect!, :verify!, :clear_cache!, :reset!
 
-      SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
+      SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|setval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
       SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
       SQL_SKIP_STICKINESS_MATCHERS  = [/\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze


### PR DESCRIPTION
[One of the commands that update sequences are not covered by the regex](https://www.postgresql.org/docs/8.2/functions-sequence.html) that decides if a query goes to master. This PR adds that command `setval`.

