### PR TITLE
Replace Digest::MD5 with OpenSSL::Digest::SHA256 for FIPS 140-2 compliance

### DIFF
--- a/lib/makara/config_parser.rb
+++ b/lib/makara/config_parser.rb
@@ -1,4 +1,4 @@
-require 'digest/md5'
+require 'openssl'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/hash/except'
 
@@ -151,7 +151,7 @@ module Makara
     def id
       @id ||= begin
         sorted = recursive_sort(@config)
-        Digest::MD5.hexdigest(sorted.to_s)
+        OpenSSL::Digest::SHA256.hexdigest(sorted.to_s)
       end
     end
 

--- a/lib/makara/context.rb
+++ b/lib/makara/context.rb
@@ -1,5 +1,3 @@
-require 'digest/md5'
-
 # Keeps track of the current stickiness state for different Makara proxies
 module Makara
   class Context


### PR DESCRIPTION
- The Ruby Digest class is not FIPS 140-2 compliant. When running in FIPS mode,
  calling Digest results in a segfault. Moreover, MD5 is not FIPS compliant and
  cannot be used in FIPS mode. Even when using OpenSSL::Digest::MD5 an exception
  will be raised.
- Remove unused require of 'digest/md5' from the context.rb