### PR TITLE
Don't treat Kafka connection errors as Makara database errors

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -20,7 +20,6 @@ module ActiveRecord
           /(closed|lost|no|terminating|terminated)\s?([^\s]+)?\sconnection/,
           /gone away/,
           /connection[^:]+refused/,
-          /could not connect/,
           /can\'t connect/,
           /cannot connect/,
           /connection[^:]+closed/,

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb
@@ -59,6 +59,14 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter::ErrorHandler d
     end
   end
 
+  it "shouldn't treat Kafka connection errors as database errors" do
+    expect {
+      handler.handle(connection) do
+        raise "Could not connect to any of the seed brokers"
+      end
+    }.to raise_error(RuntimeError)
+  end
+
   describe 'custom errors' do
 
     let(:config_path) { File.join(File.expand_path('../../../', __FILE__), 'support', 'mysql2_database_with_custom_errors.yml') }


### PR DESCRIPTION
We use Kafka alongside Makara in our app, and for some Kafka events we wrap them in a transaction as we want to roll back any changes to the database in case an event doesn't get published.

When event publication fails, a `Kafka::DeliveryFailed - Could not connect to any of the seed brokers` exception is raised:

```rb
ApplicationRecord.transaction do
  record.save
  publish_event #  may raise Kafka::DeliveryFailed - Could not connect to any of the seed brokers:
end
```

The decription `Could not connect to any of the seed brokers` however ends up catching this and re-raising it as a `Makara::Errors::AllConnectionsBlacklisted` exception, due to the line here:

https://github.com/taskrabbit/makara/blob/dac6be2e01e0511db6715b2b4da65a5490e01cba/lib/active_record/connection_adapters/makara_abstract_adapter.rb#L23

...causing some difficulties with the way we track and manage exceptions.

This PR rather naively removes `could not connect` from the list of `CONNECTION_MATCHERS`, since all specs still seem to pass, but I'm not sure if there is something I'm unaware of! 🙇 

The two errors that could have been affected, are actually caught thanks to the presence of `connection refused` in their descriptions:

https://github.com/taskrabbit/makara/blob/d609178c3ae278ba377efa2bbdaf10e4f4d71b6a/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb#L37

https://github.com/taskrabbit/makara/blob/d609178c3ae278ba377efa2bbdaf10e4f4d71b6a/spec/active_record/connection_adapters/makara_abstract_adapter_error_handling_spec.rb#L41

Let me know if I've got the wrong end of the stick! 🙏 