### PR TITLE
Fix invalid metadata key in Gemspec

### DIFF
--- a/makara.gemspec
+++ b/makara.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/taskrabbit/makara"
   gem.licenses      = ['MIT']
   gem.metadata      = {
-                        source_code_uri: 'https://github.com/taskrabbit/makara'
+                        "source_code_uri" => 'https://github.com/taskrabbit/makara'
                       }
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
It appears that recent versions of Bundler [expect "stringy" keys for metadata](https://guides.rubygems.org/specification-reference/#metadata)?

I was running into the following error:

```
Documents/makara [master] » bundle -v    
Bundler version 1.17.3

Documents/makara [master] » ruby -v
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-darwin18]

Documents/makara [master] » bundle
You have one or more invalid gemspecs that need to be fixed.
The gemspec at /Users/balvig/Documents/makara/makara.gemspec is not valid. Please fix this gemspec.
The validation error was 'metadata keys must be a String'
```