### PR TITLE
Prevent infinite loop when blacklisting disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ There are some edge cases:
 
 ### Errors / blacklisting
 
-Whenever a node fails an operation due to a connection issue, it is blacklisted for the amount of time specified in your database.yml. After that amount of time has passed, the connection will begin receiving queries again. If all slave nodes are blacklisted, the master connection will begin receiving read queries as if it were a slave. Once all nodes are blacklisted the error is raised to the application and all nodes are whitelisted.
+Whenever a node fails an operation due to a connection issue, it is blacklisted for the amount of time specified by `blacklist_duration` in your `database.yml` (30 seconds by default). After that amount of time has passed, the connection will begin receiving queries again. If all slave nodes are blacklisted, the master connection will begin receiving read queries as if it were a slave. Once all nodes are blacklisted, the error is raised to the application, and all nodes are whitelisted.
+
+By default, only connection errors will blacklist nodes (e.g., timeouts or database going away). You can configure [additional custom errors using by setting `connection_error_matchers`](#custom-error-matchers).
+
+You can disable blacklisting by setting `disable_blacklist: true` in your in your `database.yml`. When blacklisting is disabled, if a connection error happens, it will just be raised to the application. Notice that this will be the implicit behavior if you set a `blacklist_duration` of 0.
 
 ### Database.yml
 

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -117,7 +117,11 @@ module Makara
     rescue Makara::Errors::BlacklistConnection => e
       @blacklist_errors.insert(0, e)
       provided_connection._makara_blacklist!
-      retry
+      if provided_connection._makara_blacklisted?
+        retry
+      else
+        raise e.original_error
+      end
     end
 
 

--- a/makara.gemspec
+++ b/makara.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/taskrabbit/makara"
   gem.licenses      = ['MIT']
   gem.metadata      = {
-                        source_code_uri: 'https://github.com/taskrabbit/makara'
+                        'source_code_uri' => 'https://github.com/taskrabbit/makara'
                       }
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
This prevents a infinite loop situation when blacklisting connections is disabled.

When blacklisting connections are disabled, `Pool#provide` will enter into an infinite loop as long as the connection keeps raising a `BlacklistConnection` error. Because it will never be blacklisted, the current connection will always be available, and it will keep retrying. 

The problem happens when `disable_blacklisting` is `true` and also when `blacklist_duration` is 0.

The patch prevents retrying unless the connection was blacklisted.

It also includes a couple of specs. If you remove the patch and run the specs you will get the infinite loop.

I am not familiar with Makara. I'll be happy to modify the PR if you prefer a different approach.
