### PR TITLE
Replace URI.unescape(...) by CGI.unescape(...)

### DIFF
--- a/lib/makara/config_parser.rb
+++ b/lib/makara/config_parser.rb
@@ -63,7 +63,7 @@ module Makara
       # Converts the given URL to a full connection hash.
       def to_hash
         config = raw_config.reject { |_,value| value.blank? }
-        config.map { |key,value| config[key] = URI.unescape(value) if value.is_a? String }
+        config.map { |key,value| config[key] = CGI.unescape(value) if value.is_a? String }
         config
       end
 


### PR DESCRIPTION
With Ruby 2.7, this line raise `warning: URI.unescape is obsolete`.