### PR TITLE
Fixes some deprecation warnings with Ruby 2.7

### DIFF
--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -101,7 +101,7 @@ module Makara
         _makara_connection.__send__(m, *args, &block)
       end
     end
-
+    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
     class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
       def respond_to#{RUBY_VERSION.to_s =~ /^1.8/ ? nil : '_missing'}?(m, include_private = false)

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -110,6 +110,7 @@ module Makara
         end
       end
     end
+    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
     class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
       def respond_to#{RUBY_VERSION.to_s =~ /^1.8/ ? nil : '_missing'}?(m, include_private = false)

--- a/makara.gemspec
+++ b/makara.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/taskrabbit/makara"
   gem.licenses      = ['MIT']
   gem.metadata      = {
-                        source_code_uri: 'https://github.com/taskrabbit/makara'
+                        'source_code_uri' => 'https://github.com/taskrabbit/makara'
                       }
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
Fixes two deprecation warnings with Ruby 2.7  (also fixes broken gemspec so tests run)

```txt
/Users/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/makara-0.4.1/lib/makara/connection_wrapper.rb:99: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activerecord-6.0.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:294: warning: The called method `create_table' is defined here
```

and

```txt
/Users/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/makara-0.4.1/lib/makara/connection_wrapper.rb:99: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activerecord-6.0.3/lib/active_record/connection_adapters/abstract/query_cache.rb:96: warning: The called method `select_all' is defined here
```

There's one more that I wasn't sure how to address:

```txt
(eval):41: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activerecord-6.0.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:97: warning: The called method `exec_query' is defined here
```