### PR TITLE
Raise on first exceptions on master pool.

### DIFF
--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -17,6 +17,7 @@ module Makara
     autoload :MakaraError,                'makara/errors/makara_error'
     autoload :AllConnectionsBlacklisted,  'makara/errors/all_connections_blacklisted'
     autoload :BlacklistConnection,        'makara/errors/blacklist_connection'
+    autoload :BlacklistConnectionOnMaster,     'makara/errors/blacklist_connection_on_master'
     autoload :NoConnectionsAvailable,     'makara/errors/no_connections_available'
   end
 

--- a/lib/makara/errors/blacklist_connection_on_master.rb
+++ b/lib/makara/errors/blacklist_connection_on_master.rb
@@ -1,0 +1,14 @@
+module Makara
+  module Errors
+    class BlacklistConnectionOnMaster < MakaraError
+
+      attr_reader :original_error
+
+      def initialize(connection, error)
+        @original_error = error
+        super "[Makara/#{connection._makara_name}] master connection blacklisted (reraise on first error) #{error.message}."
+      end
+
+    end
+  end
+end

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -94,7 +94,6 @@ module Makara
     # that may occur within the block.
     def provide
       provided_connection = self.next
-      # puts "Provide called"
       # nil implies that it's blacklisted
       if provided_connection
         $x = @proxy

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -113,13 +113,15 @@ module Makara
         raise Makara::Errors::NoConnectionsAvailable.new(@role) unless @disabled
       end
 
-    # when a connection causes a blacklist error within the provided block, we blacklist it then retry
+    # when a connection causes a blacklist error within the provided block, we blacklist it then retry unless we are using the master connection
     rescue Makara::Errors::BlacklistConnection => e
       @blacklist_errors.insert(0, e)
       provided_connection._makara_blacklist!
+      if self.role == "master"
+        raise e
+      end
       retry
     end
-
 
 
     protected

--- a/lib/makara/pool.rb
+++ b/lib/makara/pool.rb
@@ -96,8 +96,6 @@ module Makara
       provided_connection = self.next
       # nil implies that it's blacklisted
       if provided_connection
-        $x = @proxy
-        $y = self
         if @just_black_listed_master
           e = @just_black_listed_master
           @just_black_listed_master = false


### PR DESCRIPTION
It's not safe to transparently swap the master pool connections, if we're inside a transaction at the time of the swap we can get partially committed transactions. 

The ideal check would be if on master pool, and in transaction raise, but the transaction state doesn't appear to be trivially present here. This is safe and can be improved later. 

