### PR TITLE
Override equality operator for activerecord connection wrapper

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -110,7 +110,7 @@ module ActiveRecord
       send_to_all :connect, :reconnect!, :verify!, :clear_cache!, :reset!
 
       control_method :close, :steal!, :expire, :lease, :in_use?, :owner, :schema_cache, :pool=, :pool,
-         :schema_cache=, :lock, :seconds_idle
+         :schema_cache=, :lock, :seconds_idle, :==
 
 
       SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
@@ -306,6 +306,10 @@ module ActiveRecord
 
         def pool(*args)
           @pool
+        end
+
+        def ==(*args)
+          @proxy.object_id == args[0].object_id
         end
       end
     end


### PR DESCRIPTION
This will fix proxying `==` to raw connection.

```
/var/app/vendor/cache/makara-55759103f219/lib/makara/proxy.rb:137:in `respond_to_missing?'
/var/app/vendor/ruby-2.6.5/lib/ruby/2.6.0/delegate.rb:137:in `respond_to?'
/var/app/vendor/ruby-2.6.5/lib/ruby/2.6.0/delegate.rb:137:in `=='
/var/app/vendor/ruby-2.6.5/lib/ruby/2.6.0/delegate.rb:137:in `=='
/var/app/vendor/bundle/ruby/2.6.0/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:568:in `delete'
```