### PR TITLE
Add transaction id support to makara_abstract_adapter

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -116,7 +116,7 @@ module ActiveRecord
       SQL_MASTER_MATCHERS           = [/select.+txid_current\(\)\Z/i, /\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
       SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
-      SQL_SKIP_STICKINESS_MATCHERS  = [/select.+txid_visible_in_snapshot\(/i, /\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
+      SQL_SKIP_STICKINESS_MATCHERS  = [/select.+txid_current\(\)\Z/i, /select.+txid_visible_in_snapshot\(/i, /\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
 
 
       def sql_master_matchers

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -113,10 +113,10 @@ module ActiveRecord
          :schema_cache=, :lock, :seconds_idle, :==
 
 
-      SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
+      SQL_MASTER_MATCHERS           = [/select.+txid_current\(\)\Z/i, /\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
       SQL_SLAVE_MATCHERS            = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
       SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
-      SQL_SKIP_STICKINESS_MATCHERS  = [/\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
+      SQL_SKIP_STICKINESS_MATCHERS  = [/select.+txid_visible_in_snapshot\(/i, /\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
 
 
       def sql_master_matchers

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -114,9 +114,9 @@ module ActiveRecord
 
 
       SQL_MASTER_MATCHERS           = [/select.+txid_current\(\)\Z/i, /\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
-      SQL_SLAVE_MATCHERS            = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
+      SQL_SLAVE_MATCHERS            = [/select.+txid_visible_in_snapshot\(/i, /\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
       SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
-      SQL_SKIP_STICKINESS_MATCHERS  = [/select.+txid_current\(\)\Z/i, /select.+txid_visible_in_snapshot\(/i, /\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
+      SQL_SKIP_STICKINESS_MATCHERS  = [/select.+txid_current\(\)\Z/i, /\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
 
 
       def sql_master_matchers

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -102,7 +102,6 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     'commit transaction' => true,
     'rollback transaction' => true,
     'select txid_current()' => false,
-    'select txid_visible_in_snapshot(1, txid_current_snapshot())' => false,
     %Q{
       UPDATE
         dogs

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -101,6 +101,7 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     'begin deferred transaction' => true,
     'commit transaction' => true,
     'rollback transaction' => true,
+    'select txid_current()' => false,
     'select txid_visible_in_snapshot(1, txid_current_snapshot())' => false,
     %Q{
       UPDATE

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -36,7 +36,9 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     'select get_lock(\'foo\', 0)' => true,
     'select release_lock(\'foo\')' => true,
     'select pg_advisory_lock(12345)' => true,
-    'select pg_advisory_unlock(12345)' => true
+    'select pg_advisory_unlock(12345)' => true,
+    'select txid_current()' => true,
+    'select txid_visible_in_snapshot(1, txid_current_snapshot())' => false,
   }.each do |sql, should_go_to_master|
 
     it "determines that \"#{sql}\" #{should_go_to_master ? 'requires' : 'does not require'} master" do
@@ -99,6 +101,7 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     'begin deferred transaction' => true,
     'commit transaction' => true,
     'rollback transaction' => true,
+    'select txid_visible_in_snapshot(1, txid_current_snapshot())' => false,
     %Q{
       UPDATE
         dogs


### PR DESCRIPTION
Always run `select txid_current()` on master without sticking. 