### PR TITLE
Fix on Ruby 3 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
             ruby: 3.0
           - gemfile: ar52
             ruby: ruby-head
-    continue-on-error: ${{ matrix.ruby == 3.0 || matrix.ruby == 'jruby' || matrix.ruby == 'ruby-head' || matrix.gemfile == 'ar-head' }}
+    continue-on-error: ${{ matrix.ruby == 'jruby' || matrix.ruby == 'ruby-head' || matrix.gemfile == 'ar-head' }}
     services:
       postgres:
         image: postgis/postgis:12-3.1

--- a/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
@@ -160,7 +160,12 @@ describe 'MakaraMysql2Adapter' do
       Test::User.exists? # flush other (schema) things that need to happen
 
       con = connection.replica_pool.connections.first
-      expect(con).to receive(:exec_query).with(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/, any_args).once.and_call_original
+      expect(con).to receive(:exec_query) do |query|
+        expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
+      end.once.
+        # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
+        and_wrap_original { |m, *args| m.call(*args.first(3)) }
+
       Test::User.exists?
     end
 

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -73,7 +73,13 @@ describe 'MakaraPostgreSQLAdapter' do
       Test::User.exists? # flush other (schema) things that need to happen
 
       con = connection.replica_pool.connections.first
-      expect(con).to receive(:exec_query).with(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/, any_args).once.and_call_original
+
+      expect(con).to receive(:exec_query) do |query|
+        expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
+      end.once.
+        # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
+        and_wrap_original { |m, *args| m.call(*args.first(3)) }
+
       Test::User.exists?
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,10 @@ begin
 rescue LoadError
 end
 
+if RUBY_VERSION >= "2.7.0"
+  Warning[:deprecated] = true
+end
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,13 @@ if RUBY_VERSION >= "2.7.0"
   Warning[:deprecated] = true
 end
 
+# Delete once Timecop fixes Ruby 3.1 support
+Time.class_eval do
+  class << self
+    ruby2_keywords :new if Module.private_method_defined?(:ruby2_keywords)
+  end
+end
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus


### PR DESCRIPTION
Because of how much method delegation and metaprogramming this gem uses, there were a number of issues due to the Ruby 3 keyword argument change.

Most are resolvable by adding `ruby2_keywords`, but the stuff using `instance_eval` is a bit more involved.