### PR TITLE
Deprecate 'slave' in favor of 'replica'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Deprecated the term `slave` in favor of `replica` [#286](https://github.com/instacart/makara/pull/286) Matt Larraz
 - Drop support for Ruby < 2.5 and ActiveRecord < 5.2 [#281](https://github.com/instacart/makara/pull/281) Matt Larraz
 
 ## v0.5.0 - 2021-01-08

--- a/lib/makara.rb
+++ b/lib/makara.rb
@@ -2,7 +2,6 @@ require 'active_support'
 require 'makara/version'
 require 'makara/railtie' if defined?(Rails)
 module Makara
-
   autoload :Cache,              'makara/cache'
   autoload :ConfigParser,       'makara/config_parser'
   autoload :ConnectionWrapper,  'makara/connection_wrapper'

--- a/lib/makara/logging/subscriber.rb
+++ b/lib/makara/logging/subscriber.rb
@@ -19,7 +19,7 @@ module Makara
       # uses the adapter's connection proxy to modify the name of the event
       # the name of the used connection will be prepended to the sql log
       ###
-      ### [Master|Slave] User Load (1.3ms) SELECT * FROM `users`;
+      ### [Master|Replica] User Load (1.3ms) SELECT * FROM `users`;
       ###
       def current_wrapper_name(event)
         connection_object_id = event.payload[:connection_id]

--- a/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_abstract_adapter_spec.rb
@@ -65,7 +65,7 @@ describe ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter do
     it "determines that \"#{sql}\" #{should_send_to_all_connections ? 'should' : 'should not'} be sent to all underlying connections" do
       proxy = klass.new(config(1,1))
       proxy.master_pool.connections.each{|con| expect(con).to receive(:execute).with(sql).once}
-      proxy.slave_pool.connections.each do |con|
+      proxy.replica_pool.connections.each do |con|
         if should_send_to_all_connections
           expect(con).to receive(:execute).with(sql).once
         else

--- a/spec/config_parser_spec.rb
+++ b/spec/config_parser_spec.rb
@@ -12,10 +12,10 @@ describe Makara::ConfigParser do
             :name => 'themaster'
           },
           {
-            :name => 'slave1'
+            :name => 'replica1'
           },
           {
-            :name => 'slave2'
+            :name => 'replica2'
           }
         ]
       }
@@ -108,8 +108,8 @@ describe Makara::ConfigParser do
     expect(parser.id).to eq('myproxyidwithreservedcharacters')
   end
 
-  context 'master and slave configs' do
-    it 'should provide master and slave configs' do
+  context 'master and replica configs' do
+    it 'should provide master and replica configs' do
       parser = described_class.new(config)
       expect(parser.master_configs).to eq([
         {
@@ -120,16 +120,16 @@ describe Makara::ConfigParser do
           :master_ttl => 5
         }
       ])
-      expect(parser.slave_configs).to eq([
+      expect(parser.replica_configs).to eq([
         {
-          :name => 'slave1',
+          :name => 'replica1',
           :top_level => 'value',
           :sticky => true,
           :blacklist_duration => 30,
           :master_ttl => 5
         },
         {
-          :name => 'slave2',
+          :name => 'replica2',
           :top_level => 'value',
           :sticky => true,
           :blacklist_duration => 30,
@@ -141,7 +141,7 @@ describe Makara::ConfigParser do
     it 'connection configuration should override makara config' do
       config[:makara][:blacklist_duration] = 123
       config[:makara][:connections][0][:blacklist_duration] = 456
-      config[:makara][:connections][1][:top_level] = 'slave value'
+      config[:makara][:connections][1][:top_level] = 'replica value'
 
       parser = described_class.new(config)
       expect(parser.master_configs).to eq([
@@ -153,16 +153,16 @@ describe Makara::ConfigParser do
           :master_ttl => 5
         }
       ])
-      expect(parser.slave_configs).to eq([
+      expect(parser.replica_configs).to eq([
         {
-          :name => 'slave1',
-          :top_level => 'slave value',
+          :name => 'replica1',
+          :top_level => 'replica value',
           :sticky => true,
           :blacklist_duration => 123,
           :master_ttl => 5
         },
         {
-          :name => 'slave2',
+          :name => 'replica2',
           :top_level => 'value',
           :sticky => true,
           :blacklist_duration => 123,

--- a/spec/connection_wrapper_spec.rb
+++ b/spec/connection_wrapper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Makara::ConnectionWrapper do
 
-  let(:proxy){ FakeProxy.new({:makara => {:blacklist_duration => 5, :connections => [{:role => 'master'}, {:role => 'slave'}, {:role => 'slave'}]}}) }
+  let(:proxy){ FakeProxy.new({:makara => {:blacklist_duration => 5, :connections => [{:role => 'master'}, {:role => 'replica'}, {:role => 'replica'}]}}) }
   let(:connection){ subject._makara_connection }
 
   subject{ proxy.master_pool.connections.first }

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -32,7 +32,7 @@ describe Makara::Middleware do
     _, headers, body = middleware.call(env)
 
     expect(headers).to eq({})
-    expect(body).to eq('slave/1')
+    expect(body).to eq('replica/1')
   end
 
   it 'should use the cookie-provided context if present' do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,16 +3,16 @@ module SpecHelpers
     connection = ActiveRecord::Base.establish_connection(config)
 
     # make sure these are all reset to not be blacklisted
-    ActiveRecord::Base.connection.slave_pool.connections.each(&:_makara_whitelist!)
+    ActiveRecord::Base.connection.replica_pool.connections.each(&:_makara_whitelist!)
     ActiveRecord::Base.connection.master_pool.connections.each(&:_makara_whitelist!)
 
     ActiveRecord::Base.connection
   end
 
-  def config(masters = 1, slaves = 2)
+  def config(masters = 1, replicas = 2)
     connections = []
     masters.times{ connections << {:role => 'master'} }
-    slaves.times{ connections << {:role => 'slave'} }
+    replicas.times{ connections << {:role => 'replica'} }
     {
       :makara => {
         # Defaults:

--- a/spec/support/mysql2_database.yml
+++ b/spec/support/mysql2_database.yml
@@ -14,5 +14,5 @@ test:
     master_ttl: 5
     connections:
       - role: master
-      - role: slave
-      - role: slave
+      - role: replica
+      - role: replica

--- a/spec/support/mysql2_database_with_custom_errors.yml
+++ b/spec/support/mysql2_database_with_custom_errors.yml
@@ -14,8 +14,8 @@ test:
     master_ttl: 5
     connections:
       - role: master
-      - role: slave
-      - role: slave
+      - role: replica
+      - role: replica
     connection_error_matchers:
       - !ruby/regexp '/^ActiveRecord::StatementInvalid: Mysql2::Error: Unknown command1:/'
       - "/^ActiveRecord::StatementInvalid: Mysql2::Error: Unknown command2:/i"

--- a/spec/support/postgis_database.yml
+++ b/spec/support/postgis_database.yml
@@ -11,5 +11,5 @@ test:
     master_ttl: 5
     connections:
       - role: master
-      - role: slave
-      - role: slave
+      - role: replica
+      - role: replica

--- a/spec/support/postgresql_database.yml
+++ b/spec/support/postgresql_database.yml
@@ -9,5 +9,5 @@ test:
     master_ttl: 5
     connections:
       - role: master
-      - role: slave
-      - role: slave
+      - role: replica
+      - role: replica

--- a/spec/support/proxy_extensions.rb
+++ b/spec/support/proxy_extensions.rb
@@ -1,6 +1,6 @@
 module ProxyExtensions
 
-  attr_reader :master_pool, :slave_pool, :id
+  attr_reader :master_pool, :replica_pool, :id
   
   def master_for?(sql)
     pool_for(sql) == master_pool


### PR DESCRIPTION
Replica is a clearer term to use.

Old configs and methods should still work but will trigger deprecation warnings.