### PR TITLE
Fix ar-head gemfile

### DIFF
--- a/gemfiles/ar-head.gemfile
+++ b/gemfiles/ar-head.gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 # Specify your gem"s dependencies in makara.gemspec
 gemspec path: "../"
 
-gem "activerecord", github: "rails/rails"
+gem "activerecord", github: "rails/rails", branch: "main"


### PR DESCRIPTION
Rails uses `main`, not `master`, as their default branch.

This was failing on the `bundle install` step, now we will at least run the specs.