### PR TITLE
Tick v0.6.0 pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+
+## v0.6.0.pre - 2021-01-08
+[Full Changelog](https://github.com/instacart/makara/compare/v0.5.0...v0.6.0.pre)
 - Use ActiveRecord URL resolver instead of copying definition [#294](https://github.com/instacart/makara/pull/294) Matt Larraz
 - Deprecated the term `master` in favor of `primary` [#290](https://github.com/instacart/makara/pull/290) Matt Larraz
 - Deprecated the term `slave` in favor of `replica` [#286](https://github.com/instacart/makara/pull/286) Matt Larraz
+- Fix Ruby 2.7 kwarg warning and add Ruby 3 support [#283](https://github.com/instacart/makara/pull/283) Matt Larraz
 - Drop support for Ruby < 2.5 and ActiveRecord < 5.2 [#281](https://github.com/instacart/makara/pull/281) Matt Larraz
 
 ## v0.5.0 - 2021-01-08

--- a/lib/makara/version.rb
+++ b/lib/makara/version.rb
@@ -1,9 +1,9 @@
 module Makara
   module VERSION
     MAJOR = 0
-    MINOR = 5
+    MINOR = 6
     PATCH = 0
-    PRE = nil
+    PRE = "pre"
 
     def self.to_s
       [MAJOR, MINOR, PATCH, PRE].compact.join('.')

--- a/lib/makara/version.rb
+++ b/lib/makara/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Makara
   module VERSION
     MAJOR = 0


### PR DESCRIPTION
There's been [a lot of changes since 0.5.0](https://github.com/instacart/makara/compare/v0.5.0...e584045), so let's cut a pre-release first to identify any production issues. If all goes smoothly, we can cut a full release shortly afterwards.