### PR TITLE
Fix verbose query logger in ActiveRecord

### DIFF
--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -181,7 +181,7 @@ module Makara
       end
 
       # extend the instance
-      con.instance_eval(extension)
+      con.instance_eval(extension, __FILE__, __LINE__ + 1)
       # set the makara context
       con._makara = @proxy
 


### PR DESCRIPTION
Before:
```
↳ (eval):51:in `block in exec_no_cache'
```

After:
```
↳ app/controllers/foo_controller.rb:5:in `some_method'
```

ActiveRecord has a feature called `verbose_query_logger = true`. It simply displays the line that caused the query to be executed. Instead of displaying the correct line, the logger was displaying the `eval` line from Makara. This is because it uses `ActiveSupport::BacktraceCleaner` on `caller`, which filters out any code from gems and stdlib, to find the original caller. Since `, __FILE__, __LINE__ + 1` wasn't being specified on the connection wrapper, it was incorrectly identifying the connection wrapper eval as the original caller (essentially breaking the feature).