### PR TITLE
Remove RSpec hack

### DIFF
--- a/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
@@ -157,9 +157,7 @@ describe 'MakaraMysql2Adapter' do
       con = connection.replica_pool.connections.first
       expect(con).to receive(:exec_query) do |query|
         expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
-      end.once.
-        # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
-        and_wrap_original { |m, *args| m.call(*args.first(3)) }
+      end.once.and_call_original
 
       Test::User.exists?
     end

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -73,9 +73,7 @@ describe 'MakaraPostgreSQLAdapter' do
 
       expect(con).to receive(:exec_query) do |query|
         expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
-      end.once.
-        # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
-        and_wrap_original { |m, *args| m.call(*args.first(3)) }
+      end.once.and_call_original
 
       Test::User.exists?
     end


### PR DESCRIPTION
This is no longer needed as of [rspec-mocks 3.10.2](https://github.com/rspec/rspec-mocks/blob/main/Changelog.md#3102--2021-01-27)