### PR TITLE
Check that decorated connection responds to open_transactions before invoking

### DIFF
--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -44,7 +44,7 @@ module Makara
     end
 
     def _makara_in_transaction?
-      @connection && @connection.open_transactions > 0
+      @connection && @connection.respond_to?(:open_transactions) && @connection.open_transactions > 0
     end
 
     # blacklist this node for @config[:blacklist_duration] seconds


### PR DESCRIPTION
We have an instance of a Makara proxy we use for Redis, for read-write splitting. It looks like this:

```ruby
class RedisProxy < Makara::Proxy

  # ...

  def connection_for(config)
    Redis.new(config)
  end

  # ...
end
```
The connection returned is an instance of [a Redis client](https://github.com/redis/redis-rb), which doesn't respond to `open_transactions`, so after updating to [v0.5.1](https://github.com/instacart/makara/releases/tag/v0.5.1), any errors on Redis that would result in a `Makara::Errors::BlacklistConnection`, now result in a `Redis::CommandError: ERR unknown command 'open_transactions'`.  

This PR addresses this. Let me know if you'd prefer an alternative approach or anything else!