### PR TITLE
Adds the ability to retry for the pool of connection if specified in makara config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -63,10 +63,10 @@ module Makara
       false
     end
 
-    def _makara_connection
+    def _makara_connection(force_new = false)
       current = @connection
 
-      if current
+      if current && !force_new
         current
       else # blacklisted connection or initial error
         new_connection = @proxy.graceful_connection_for(@config)
@@ -90,7 +90,35 @@ module Makara
         end
       end
 
-      _makara_connection.execute(*args)
+      if @proxy.config.key?(:retry_exceptions) && (retry_exceptions = @proxy.config[:retry_exceptions]).present?
+        _execute_with_retry(retry_exceptions, *args)
+      else
+        _makara_connection.execute(*args)
+      end
+    end
+
+    MAX_RETRY_ATTEMPTS = 10
+
+    # Attempt to retry the execution by re-establishing the connection
+    def _execute_with_retry(retry_exceptions, *args)
+      retry_attempts = retry_exceptions.inject({}).map { |memo, retry_exception| memo[retry_exception['name']] = 0 }
+      begin
+        _makara_connection.execute(*args)
+      rescue Exception => actual_exception
+        retry_exceptions.each do |retry_exception|
+          if actual_exception.class.to_s == retry_exception
+            _makara_connection(true) # Force new connection to re-try.
+            sleep retry_exception['time_between_retries_in_seconds'] || 0.1
+            retry_attempt = (retry_attempts[actual_exception.class.to_s] += 1)
+
+            if retry_attempt < retry_exception['retry_count'] && retry_attempt < MAX_RETRY_ATTEMPTS
+              retry
+            end
+          end
+        end
+
+        raise actual_exception
+      end
     end
 
     # we want to forward all private methods, since we could have kicked out from a private scenario

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -107,7 +107,7 @@ module Makara
         _makara_connection.execute(*args)
       rescue Exception => actual_exception
         retry_exceptions.each do |retry_exception|
-          if actual_exception.class.to_s == retry_exception
+          if actual_exception.class.to_s == retry_exception['name']
             _makara_connection(true) # Force new connection to re-try.
             sleep retry_exception['time_between_retries_in_seconds'] || 0.1
             retry_attempt = (retry_attempts[actual_exception.class.to_s] += 1)

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -103,6 +103,7 @@ module Makara
     def _execute_with_retry(retry_exceptions, *args)
       retry_attempts = retry_exceptions.inject({}).map { |memo, retry_exception| memo[retry_exception['name']] = 0 }
       begin
+        should_retry = false
         _makara_connection.execute(*args)
       rescue Exception => actual_exception
         retry_exceptions.each do |retry_exception|
@@ -112,11 +113,11 @@ module Makara
             retry_attempt = (retry_attempts[actual_exception.class.to_s] += 1)
 
             if retry_attempt < retry_exception['retry_count'] && retry_attempt < MAX_RETRY_ATTEMPTS
-              retry
+              should_retry = true
             end
           end
         end
-
+        retry if should_retry
         raise actual_exception
       end
     end

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -101,7 +101,7 @@ module Makara
 
     # Attempt to retry the execution by re-establishing the connection
     def _execute_with_retry(retry_exceptions, *args)
-      retry_attempts = retry_exceptions.inject({}).map { |memo, retry_exception| memo[retry_exception['name']] = 0 }
+      retry_attempts = retry_exceptions.inject({}) { |memo, retry_exception| memo[retry_exception['name']] = 0; memo }
       begin
         should_retry = false
         _makara_connection.execute(*args)

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -44,42 +44,6 @@ module Makara
           end
         end
       end
-
-      private
-
-      def _execute_with_connection_and_retry_exceptions(retry_exceptions, args, block, method_name)
-        begin
-          should_retry = false
-          potentially_stale_connection = nil
-
-          appropriate_connection(method_name, args) do |con|
-            con.send(method_name, *args, &block)
-            potentially_stale_connection = con
-          end
-
-        rescue Exception => actual_exception
-          retry_attempts = retry_exceptions.inject({}) { |memo, retry_exception| memo[retry_exception['name']] = 0; memo }
-          retry_exceptions.each do |retry_exception|
-            if actual_exception.class.to_s == retry_exception['name']
-              potentially_stale_connection.disconnect!
-              sleep retry_exception['time_between_retries_in_seconds'] || 0.1
-              retry_attempt = (retry_attempts[actual_exception.class.to_s] += 1)
-
-              if retry_attempt < retry_exception['retry_count'] && retry_attempt < MAX_RETRY_ATTEMPTS
-                should_retry = true
-              end
-            end
-          end
-          retry if should_retry
-          raise actual_exception
-        end
-      end
-
-      def _execute_with_connection(args, block, method_name)
-        appropriate_connection(method_name, args) do |con|
-          con.send(method_name, *args, &block)
-        end
-      end
     end
 
 
@@ -201,6 +165,40 @@ module Makara
         end
       ensure
         @master_pool.disabled = false
+      end
+    end
+
+    def _execute_with_connection_and_retry_exceptions(retry_exceptions, args, block, method_name)
+      begin
+        should_retry = false
+        potentially_stale_connection = nil
+
+        appropriate_connection(method_name, args) do |con|
+          con.send(method_name, *args, &block)
+          potentially_stale_connection = con
+        end
+
+      rescue Exception => actual_exception
+        retry_attempts = retry_exceptions.inject({}) { |memo, retry_exception| memo[retry_exception['name']] = 0; memo }
+        retry_exceptions.each do |retry_exception|
+          if actual_exception.class.to_s == retry_exception['name']
+            potentially_stale_connection.disconnect!
+            sleep retry_exception['time_between_retries_in_seconds'] || 0.1
+            retry_attempt = (retry_attempts[actual_exception.class.to_s] += 1)
+
+            if retry_attempt < retry_exception['retry_count'] && retry_attempt < MAX_RETRY_ATTEMPTS
+              should_retry = true
+            end
+          end
+        end
+        retry if should_retry
+        raise actual_exception
+      end
+    end
+
+    def _execute_with_connection(args, block, method_name)
+      appropriate_connection(method_name, args) do |con|
+        con.send(method_name, *args, &block)
       end
     end
 

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -18,8 +18,6 @@ module Makara
     self.hijack_methods = []
 
     class << self
-      MAX_RETRY_ATTEMPTS = 10
-
       def hijack_method(*method_names)
         self.hijack_methods = self.hijack_methods || []
         self.hijack_methods |= method_names
@@ -168,6 +166,8 @@ module Makara
       end
     end
 
+    MAX_RETRY_COUNT = 10
+
     def _execute_with_connection_and_retry_exceptions(retry_exceptions, args, block, method_name)
       begin
         should_retry = false
@@ -186,7 +186,8 @@ module Makara
             sleep retry_exception['time_between_retries_in_seconds'] || 0.1
             retry_attempt = (retry_attempts[actual_exception.class.to_s] += 1)
 
-            if retry_attempt < retry_exception['retry_count'] && retry_attempt < MAX_RETRY_ATTEMPTS
+            max_attempts = retry_exception['retry_count'] || MAX_RETRY_COUNT
+            if retry_attempt < max_attempts
               should_retry = true
             end
           end

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -187,7 +187,7 @@ module Makara
             retry_attempt = (retry_attempts[actual_exception.class.to_s] += 1)
 
             max_attempts = retry_exception['retry_count'] || MAX_RETRY_COUNT
-            if retry_attempt < max_attempts
+            if retry_attempt < max_attempts && retry_attempt < MAX_RETRY_COUNT
               should_retry = true
             end
           end


### PR DESCRIPTION
This is an attempt to do graceful failover by re-trying at the lowest level.
(This isn't ready to be merged in master for makara but we'll use this branch)

Example config:

```
development:
  database: speckel_development
  adapter: postgresql_makara
  host: localhost
  username: speckel
  password: 23432
  pool: 20
  makara:
    id: 'development-app-postgres'
    disable_blacklist: true
    master_ttl: 0.3
    sticky: true
    retry_exceptions:
      - name: ActiveRecord::StatementInvalid
        retry_count: 5
        time_between_retries_in_seconds: 0.2
    connections:
      - role: master
        name: DB-Writer
        host: localhost
        port: 5432
        blacklist_duration: 0
      - role: slave
        name: DB-Reader
        host: localhost
        port: 5433

```