### PR TITLE
Check decorated connection responds to open_transactions before invoking

### DIFF
--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -44,7 +44,7 @@ module Makara
     end
 
     def _makara_in_transaction?
-      @connection && @connection.open_transactions > 0
+      @connection && @connection.respond_to?(:open_transactions) && @connection.open_transactions > 0
     end
 
     # blacklist this node for @config[:blacklist_duration] seconds

--- a/spec/support/mock_objects.rb
+++ b/spec/support/mock_objects.rb
@@ -1,6 +1,6 @@
 require 'active_record/connection_adapters/makara_abstract_adapter'
 
-class FakeConnection < Struct.new(:config)
+class FakeConnectionBase < Struct.new(:config)
   def ping
     'ping!'
   end
@@ -17,16 +17,18 @@ class FakeConnection < Struct.new(:config)
     true
   end
 
-  def open_transactions
-    (config || {}).fetch(:open_transactions, 0)
-  end
-
   def disconnect!
     true
   end
 
   def something
     (config || {})[:something]
+  end
+end
+
+class FakeConnection < FakeConnectionBase
+  def open_transactions
+    (config || {}).fetch(:open_transactions, 0)
   end
 end
 


### PR DESCRIPTION
An `ActiveRecord::Base.connection` responds to open_transactions but other connections such as a Redis client do not.

Continues from and closes https://github.com/instacart/makara/pull/324, I've also added the specs as discussed there.

As per @rosa's original PR:

We have an instance of a Makara proxy we use for Redis, for read-write splitting. It looks like this:
```rb
class RedisProxy < Makara::Proxy

  # ...

  def connection_for(config)
    Redis.new(config)
  end

  # ...
end
```

The connection returned is an instance of a Redis client, which doesn't respond to open_transactions, so after updating to v0.5.1, any errors on Redis that would result in a Makara::Errors::BlacklistConnection, now result in a Redis::CommandError: ERR unknown command 'open_transactions'.

