### PR TITLE
Refer connection payload in addition to connection_id

### DIFF
--- a/lib/makara/logging/subscriber.rb
+++ b/lib/makara/logging/subscriber.rb
@@ -21,10 +21,11 @@ module Makara
       ### [Primary|Replica] User Load (1.3ms) SELECT * FROM `users`;
       ###
       def current_wrapper_name(event)
+        connection = event.payload[:connection]
         connection_object_id = event.payload[:connection_id]
-        return nil unless connection_object_id
+        return nil unless connection || connection_object_id
 
-        adapter = ObjectSpace._id2ref(connection_object_id)
+        adapter = connection || ObjectSpace._id2ref(connection_object_id)
 
         return nil unless adapter
         return nil unless adapter.respond_to?(:_makara_name)


### PR DESCRIPTION
https://github.com/rails/rails/commit/d140ab073f296a2a689a4dbd58cf9434c6b2a484

<code>connection_id</code> is removed from <code>sql.active_record</code>notification in this commit.
So It was no longer showing up in the log in Rails6.1

I fixed it by referring to <code>event.payload[:connection]</code> in addition to <code>event.payload[:connection_id]</code>