### PR TITLE
Correctly delegate the arguments

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,12 +17,14 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
           - head
           - jruby
         activerecord:
           - '5.2'
           - '6.0'
           - '6.1'
+          - '7.0'
           - head
         exclude:
           - activerecord: '5.2'

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -90,14 +90,14 @@ module Makara
       end
     end
 
-    def execute(*args)
+    def execute(*args, **kwargs)
       SQL_REPLACE.each do |find, replace|
         if args[0] == find
           args[0] = replace
         end
       end
 
-      _makara_connection.execute(*args)
+      _makara_connection.execute(*args, **kwargs)
     end
 
     # we want to forward all private methods, since we could have kicked out from a private scenario


### PR DESCRIPTION
Hi,

This PR fixes an issue with Makara when running Rails 7. 

The issue was that the method signature changed in Rails 7, so the delegation of args needed to be revised.

```
ArgumentError:
  wrong number of arguments (given 3, expected 1..2)
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/mysql/database_statements.rb:43:in `execute'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/marginalia-1.11.1/lib/marginalia.rb:71:in `execute_with_marginalia'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/connection_wrapper.rb:213:in `block in execute'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/connection_wrapper.rb:198:in `_makara_hijack'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/connection_wrapper.rb:209:in `execute'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/connection_wrapper.rb:100:in `execute'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:28:in `block (3 levels) in hijack_method'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/active_record/connection_adapters/makara_abstract_adapter.rb:141:in `block in appropriate_connection'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:202:in `block (3 levels) in appropriate_connection'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:266:in `hijacked'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:201:in `block (2 levels) in appropriate_connection'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/pool.rb:109:in `block in provide'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/active_record/connection_adapters/makara_abstract_adapter.rb:31:in `handle'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/pool.rb:108:in `provide'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:200:in `block in appropriate_connection'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:212:in `appropriate_pool'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:199:in `appropriate_connection'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/active_record/connection_adapters/makara_abstract_adapter.rb:140:in `appropriate_connection'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:27:in `block (2 levels) in hijack_method'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/connection_wrapper.rb:211:in `public_send'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/connection_wrapper.rb:211:in `block in execute'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/connection_wrapper.rb:200:in `_makara_hijack'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/connection_wrapper.rb:209:in `execute'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:207:in `execute_and_free'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:821:in `column_definitions'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:116:in `columns'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/connection_wrapper.rb:105:in `method_missing'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:130:in `block in method_missing'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:181:in `block in any_connection'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/pool.rb:109:in `block in provide'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/active_record/connection_adapters/makara_abstract_adapter.rb:31:in `handle'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/pool.rb:108:in `provide'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:180:in `any_connection'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/makara-0.5.1/lib/makara/proxy.rb:128:in `method_missing'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/schema_cache.rb:117:in `block in columns'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/schema_cache.rb:116:in `fetch'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/schema_cache.rb:116:in `columns'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/schema_cache.rb:125:in `block in columns_hash'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/schema_cache.rb:124:in `fetch'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/connection_adapters/schema_cache.rb:124:in `columns_hash'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/model_schema.rb:568:in `load_schema!'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/attributes.rb:264:in `load_schema!'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/encryption/encryptable_record.rb:122:in `load_schema!'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/model_schema.rb:554:in `block in load_schema'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/model_schema.rb:551:in `synchronize'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/model_schema.rb:551:in `load_schema'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/model_schema.rb:417:in `attribute_types'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/attribute_methods.rb:164:in `attribute_names'
# /Users/Nerian/satchel/show-app/backend/shared/gems/smhw-business-logic/app/models/notification_preference.rb:44:in `notification_fields'
# /Users/Nerian/satchel/show-app/backend/shared/gems/smhw-business-logic/app/models/user.rb:143:in `<class:User>'
# /Users/Nerian/satchel/show-app/backend/shared/gems/smhw-business-logic/app/models/user.rb:1:in `<main>'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/dead_end-4.0.0/lib/dead_end/core_ext.rb:71:in `require'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.6.0/lib/zeitwerk/kernel.rb:27:in `require'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/dependencies/require_dependency.rb:19:in `require_dependency'
# /Users/Nerian/satchel/show-app/backend/shared/gems/smhw-business-logic/config/initializers/01_eager_load.rb:2:in `block in <main>'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:445:in `instance_exec'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:445:in `block in make_lambda'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:199:in `block (2 levels) in halting'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:687:in `block (2 levels) in default_terminator'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:686:in `catch'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:686:in `block in default_terminator'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:200:in `block in halting'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:595:in `block in invoke_before'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:595:in `each'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:595:in `invoke_before'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/callbacks.rb:106:in `run_callbacks'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/activesupport-7.0.3.1/lib/active_support/reloader.rb:88:in `prepare!'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3.1/lib/rails/application/finisher.rb:68:in `block in <module:Finisher>'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3.1/lib/rails/initializable.rb:32:in `instance_exec'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3.1/lib/rails/initializable.rb:32:in `run'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3.1/lib/rails/initializable.rb:61:in `block in run_initializers'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3.1/lib/rails/initializable.rb:60:in `run_initializers'
# /Users/Nerian/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3.1/lib/rails/application.rb:372:in `initialize!'
# ./config/environment.rb:5:in `<top (required)>'
# ./spec/rails_helper.rb:4:in `require'
# ./spec/rails_helper.rb:4:in `<top (required)>'
```