### PR TITLE
Early check connection blacklisting

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -95,10 +95,22 @@ module ActiveRecord
       control_method :close, :steal!, :expire, :lease, :in_use?, :owner, :schema_cache, :pool=, :pool,
          :schema_cache=, :lock, :seconds_idle, :==
 
-      SQL_MASTER_MATCHERS           = [/\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i, /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i].map(&:freeze).freeze
-      SQL_SLAVE_MATCHERS            = [/\A\s*(select|with.+\)\s*select)\s/i].map(&:freeze).freeze
-      SQL_ALL_MATCHERS              = [/\A\s*set\s/i].map(&:freeze).freeze
-      SQL_SKIP_STICKINESS_MATCHERS  = [/\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i, /\A\s*(set|describe|explain|pragma)\s/i].map(&:freeze).freeze
+      SQL_MASTER_MATCHERS           = [
+        /\A\s*select.+for update\Z/i,
+        /select.+lock in share mode\Z/i,
+        /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock|pg_try_advisory_lock)\(/i,
+        /\A\s*select.+from pg_locks/i
+      ].map(&:freeze).freeze
+      SQL_SLAVE_MATCHERS            = [
+        /\A\s*(select|with.+\)\s*select)\s/i
+      ].map(&:freeze).freeze
+      SQL_ALL_MATCHERS              = [
+        /\A\s*set\s/i
+      ].map(&:freeze).freeze
+      SQL_SKIP_STICKINESS_MATCHERS  = [
+        /\A\s*show\s([\w]+\s)?(field|table|database|schema|view|index)(es|s)?/i,
+        /\A\s*(set|describe|explain|pragma)\s/i
+      ].map(&:freeze).freeze
 
       def sql_master_matchers
         SQL_MASTER_MATCHERS

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -71,6 +71,10 @@ module Makara
     end
 
     def _makara_connection
+      if _makara_blacklisted? && initial_error
+        raise Makara::Errors::BlacklistConnection.new(self, initial_error)
+      end
+
       current = @connection
 
       if current

--- a/lib/makara/connection_wrapper.rb
+++ b/lib/makara/connection_wrapper.rb
@@ -84,8 +84,9 @@ module Makara
 
         # Already wrapped because of initial failure
         if new_connection.is_a?(Makara::ConnectionWrapper)
+          initial_error = new_connection.initial_error
           _makara_blacklist!
-          raise Makara::Errors::BlacklistConnection.new(self, new_connection.initial_error)
+          raise Makara::Errors::BlacklistConnection.new(self, initial_error)
         else
           @connection = new_connection
           _makara_decorate_connection(new_connection)


### PR DESCRIPTION
With these changes I want to fix the problem described in https://github.com/instacart/makara/issues/258 where lot of connection attempts are performed when primary/replica DBs configuration isn't usable.

I found that `_makara_connection` method tries to establish connection everytime it's called when `@connection` is `nil`, also when blacklisted. I added an early check on blacklisting status.

I also added some unit tests for this method.

(closed PR for old version [here](https://github.com/instacart/makara/pull/277))