### PR TITLE
Use `SchemaReflection` and `BoundSchemaReflection` instead of `SchemaCache`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -212,8 +212,12 @@ module ActiveRecord
           @proxy = proxy
           @owner = nil
           @pool = nil
-          schema_reflection = ActiveRecord::ConnectionAdapters::SchemaReflection.new(nil).load!(@proxy)
-          @schema_cache = ActiveRecord::ConnectionAdapters::BoundSchemaReflection.new(schema_reflection, @proxy)
+          if ActiveRecord.version >= Gem::Version.new('7.1.0')
+            schema_reflection = ActiveRecord::ConnectionAdapters::SchemaReflection.new(nil).load!(@proxy)
+            @schema_cache = ActiveRecord::ConnectionAdapters::BoundSchemaReflection.new(schema_reflection, @proxy)
+          else
+            @schema_cache = ActiveRecord::ConnectionAdapters::SchemaCache.new @proxy
+          end
           @idle_since = Concurrent.monotonic_time
           @adapter = ActiveRecord::ConnectionAdapters::AbstractAdapter.new(@proxy)
         end

--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -212,7 +212,8 @@ module ActiveRecord
           @proxy = proxy
           @owner = nil
           @pool = nil
-          @schema_cache = ActiveRecord::ConnectionAdapters::SchemaCache.new @proxy
+          schema_reflection = ActiveRecord::ConnectionAdapters::SchemaReflection.new(nil).load!(@proxy)
+          @schema_cache = ActiveRecord::ConnectionAdapters::BoundSchemaReflection.new(schema_reflection, @proxy)
           @idle_since = Concurrent.monotonic_time
           @adapter = ActiveRecord::ConnectionAdapters::AbstractAdapter.new(@proxy)
         end


### PR DESCRIPTION
Rails 7.1 warns that `ActiveRecord::ConnectionAdapters::SchemaCache` will be removed in Rails 7.2.

I tried to look around at what was being returned by `ActiveRecord::ConnectionAdapters::SchemaCache` and try to rebuild the exact same class and this seems to work out.

Ran the CI on our end and it seems to work if I use the `ActiveRecord` version as a condition for the switch. There's most-likely a better way of doing this if you have suggestions.

---

Solves #382 