### PR TITLE
Fix arity bug with owner method inline with other pool overrides

### DIFF
--- a/lib/active_record/connection_adapters/makara_abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/makara_abstract_adapter.rb
@@ -205,9 +205,6 @@ module ActiveRecord
       end
 
       class ActiveRecordPoolControl
-        attr_reader :owner
-        alias in_use? owner
-
         def initialize(proxy)
           @proxy = proxy
           @owner = nil
@@ -300,6 +297,12 @@ module ActiveRecord
         def ==(*args)
           @proxy.equal?(args[0])
         end
+
+        def owner(*_args)
+          @owner
+        end
+
+        alias in_use? owner
       end
     end
   end


### PR DESCRIPTION
Hey, this should fix kind of an obscure error coming from the connection wrapper when an error condition is met. For example, in my case, this error is thrown when there is a deadlock and the transaction is rolled back:
```ruby
# ArgumentError
# wrong number of arguments (given 1, expected 0)
# gems/makara-0.5.1/lib/makara/connection_wrapper.rb:296 owner
```
Updates the `owner` method to conform to other methods in the abstract adapter, which generally ignore any arguments given, but all accept a splat of args.

In case it's helpful, I ran into this problem on Rails `6.1.7.3` using the latest published version of this gem `0.5.1`